### PR TITLE
Implement external links extension

### DIFF
--- a/docs/links/__init__.py
+++ b/docs/links/__init__.py
@@ -1,0 +1,6 @@
+from os.path import dirname, basename, isfile
+
+import glob
+modules = glob.glob(dirname(__file__)+"/*.py")
+
+__all__ = [ basename(f)[:-3] for f in modules if isfile(f)]

--- a/docs/links/link.py
+++ b/docs/links/link.py
@@ -1,0 +1,3 @@
+
+
+xref_links = {"key" : ("link text", "URL")}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,14 @@
 # Configuration file for the Sphinx documentation builder.
 
+import sys, os
+import sphinx_rtd_theme
+
+sys.path.append(os.path.abspath('ext'))
+sys.path.append('.')
+
+from links.link import *
+from links import *
+
 # -- Project information
 
 project = 'Mautic Documentation'


### PR DESCRIPTION
This implements the [external links extension](https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html#use-the-external-links-extension) for Read the Docs, which is the recommended way to reduce duplication of external links.

Per the documentation on the page above, this PR:

- Adds an __init__.py file
- Adds /links within the root
- Adds link.py to the links folder
- Adds external links support to the conf.py file (I copied this part from the developer docs to ensure the syntax was correct!)

