### PR TITLE
Add Mautic 3 upgrade docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,15 @@ how to :ref:`installation` the project.
    getting_started/how_to_update_mautic
 
 .. toctree::
+   :caption: Mautic 3 upgrade
+   :maxdepth: 2
+   :hidden:
+
+   mautic_3_upgrade/getting_started
+   mautic_3_upgrade/upgrade_steps
+   mautic_3_upgrade/upgrade_errors
+
+.. toctree::
    :caption: Set Up
    :maxdepth: 2
    :hidden:

--- a/docs/links/mautic_3_support_forum.py
+++ b/docs/links/mautic_3_support_forum.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic 3 Support Forum" 
+link_text = "Mautic 3 Support Forum" 
+link_url = "https://forum.mautic.org/c/support/mautic-3-install-upgrade-support/98" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_3_upgrade_file.py
+++ b/docs/links/mautic_3_upgrade_file.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic 3 Upgrade" 
+link_text = "Mautic 3 Upgrade 
+link_url = "https://github.com/mautic/mautic/blob/3.x/UPGRADE-3.0.md#configuration" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/mautic_3_upgrade/getting_started.rst
+++ b/docs/mautic_3_upgrade/getting_started.rst
@@ -1,0 +1,75 @@
+Upgrading to Mautic 3
+#####################
+
+Are you ready for Mautic 3? Time to get started.
+
+Not ready to upgrade yet?
+*************************
+
+What if you don't want to upgrade to Mautic 3 yet, how do you turn off the upgrade notification?
+
+That's absolutely fine. This is handy, for example, when you use custom Plugins that aren't ready for Mautic 3 (yet). Go to ``app/config/local.php`` and add the following setting there:
+
+.. code-block:: php
+    `block_mautic_3_upgrade'    => true,
+
+Then, clear your cache. The Mautic 3 upgrade notification now disappears. If it doesn't disappear immediately, you can run ``app/console mautic:update:find`` on the command line so that it's hidden immediately.
+
+Check the minimum requirements
+******************************
+
+Mautic 3 has some higher minimum requirements than Mautic 2, and the upgrade has some built in checks to ensure the environment supports the update, in addition to ensuring you have the resources available in your hosting environment to complete the upgrade process. Check the :xref:`Download Requirements` for the latest version of Mautic.
+
+The main things to be aware of are:
+
+1. PHP must be at 7.3 but no higher to start the update. This is because you need to be able to run Mautic 2 - 7.3 and below - and Mautic 3 - 7.4 and below - in tandem.
+
+PHP 7.3 allows you to do this. As soon as the update completes and you are running the latest released version of Mautic 3.x you can raise the PHP version to 7.4. 
+
+Check what version of PHP is in use by accessing the system information for your Mautic instance - located under the settings cog wheel at the top right - or using the command ``php -v`` at the command line. Note that there may be a different version of PHP used at the command line.
+
+2. MySQL needs to be >= 5.7.14 or if you use MariaDB, this must be >= 10.1. Check this in the system information for your Mautic instance, or using the command ``mysql -V`` at the command line.
+
+3. At least 2x the space that your Mautic 2.x instance is using currently. Remember to include your database size should in this calculation, in addition to files and folders.
+
+4. PHP's max_execution_time should be either 0 - unlimited - or > 240, otherwise the upgrade is likely to fail if using the user interface
+
+5. PHP's memory_limit should be equal to or higher than 256M otherwise the upgrade is likely to fail if using the user interface
+
+Choose your update method - web interface or command line (CLI)
+***************************************************************
+
+Command line interface - preferred
+==================================
+
+It's strongly recommended to upgrade at the command line, as the process is quite resource intensive and times out in hosting environments with limits on script execution time. If you have over 10,000 Contacts you must update using the command line.
+
+1. Take a backup of your Mautic instance, and test that it's working in all respects. 
+2. Connect to your server at the command line and use the ``cd`` command to move into the directory where you have Mautic installed
+3. Ensure that your server meets the minimum requirements listed previously
+4. Update to the latest available version of Mautic 2.x using ``app/console mautic:update:find`` to find updates, and then ``app/console mautic:update:apply``to apply the updates
+5. Remove any custom Themes and Plugins from your Mautic instance - you can bring them back in after you have completed the migration. 
+6. Run the command once again for updates using ``app/console mautic:update:find`` to find updates, and then ``app/console mautic:update:apply``to apply the updates
+7. Follow the steps - the script takes you through the migration process step by step
+
+User interface - not recommended
+================================
+
+1. Take a backup of your Mautic instance, and test that it's working in all respects. 
+2. Open your Mautic instance and look for the notification of an update being available in the notification bell
+3. Ensure that your server meets the minimum requirements listed previously
+4. Update to the latest available version of Mautic 2.x
+5. Once you are at the latest version of Mautic 2.x, look for the notification of the 3.x update being available, then you can run the upgrade script via the notification
+
+Updating cron jobs
+******************
+
+As there are significant changes in Mautic 3's file structure, you need to upgrade your cron jobs.
+
+Example:
+
+``app/console mautic:segments:update``
+
+should now be:
+
+``bin/console mautic:segments:update``

--- a/docs/mautic_3_upgrade/upgrade_errors.rst
+++ b/docs/mautic_3_upgrade/upgrade_errors.rst
@@ -1,0 +1,166 @@
+Mautic 3 upgrade errors
+#######################
+
+
+Did you get an error while running the Mautic 3 upgrade? Please look for the error code you got on this page for further instructions.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+Error codes
+===========
+
+ERR_DATABASE_BACKUP_FAILED
+**************************
+
+During this stage, the script makes an attempt to back up your database. The script makes use of the command ``mysqldump`` to execute the backup process. 
+
+If an error occurs in this stage there was a problem running the command, or there was an interruption in the process for some reason. 
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade starts.
+
+To move forward from this stage, you need to fix the problem reported, and restart the upgrade script. 
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_MAUTIC_2_MIGRATIONS_IDENTIFICATION_FAILED
+*********************************************
+
+During this stage, the script checks to ensure that there are no database migrations outstanding from previous Mautic upgrades.
+
+If an error occurs in this stage, the upgrade script was unable to find or access the appropriate files, or there was an interruption in the process for some reason.
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade starts.
+
+To move forward from this stage, refresh the page.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_MAUTIC_2_MIGRATIONS_FAILED
+******************************
+
+During this stage, the script runs the migrations identified in the previous stage, updating your Mautic 2 database to support Mautic 3.
+
+If an error occurs in this stage, the upgrade script was unable to apply the migrations that it found, or there was an interruption in the process for some reason.
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade has started.
+
+To move forward from this stage, review the error message and address any problems that it raises.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_DOWNLOAD_UPGRADE_PACKAGE_FAILED
+***********************************
+
+During this stage, the script downloads the upgrade package from the server.
+
+If an error occurs in this stage, the script was unable to contact the server to download the package needed to run the upgrade, or there was an interruption in the process for some reason.
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade has started.
+
+To move forward from this stage, review the error message and address any problems that it raises.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_EXTRACT_UPGRADE_PACKAGE_FAILED
+**********************************
+
+During this stage, the script extracts the Mautic 3 files from the downloaded archive.
+
+If an error occurs in this stage, the script was unable to extract the files on your server, or there was an interruption in the process for some reason.
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade has started.
+
+To move forward from this stage, review the error message and address any problems that it raises.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_MOVE_MAUTIC_2_AND_3_FILES
+*****************************
+
+During this stage, the script moves the current Mautic 2 files into a temporary directory called `mautic-2-backup-files`, and then moves the Mautic 3 files from "mautic-3-temp-files" to the root directory
+
+If an error occurs in this stage, there were problems with moving the files and/or folders, or there was an interruption in the process for some reason.
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade has started.
+
+To move forward from this stage, review the error message and address any problems that it raises.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_UPDATE_LOCAL_CONFIG
+***********************
+
+During this stage the script updates the config/local.php file with new Mautic 3 values.  
+
+If an error occurs in this stage, there were problems with making or saving changes to the file. 
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade has started.
+
+To move forward from this stage, review the error message and address any problems that it raises.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_MAUTIC_3_MIGRATIONS_IDENTIFICATION_FAILED
+*********************************************
+
+During this stage, the script identifies the database migrations required to update from Mautic 2 to Mautic 3.
+
+If an error occurs during this stage, the upgrade script was unable to find or access the appropriate files, or there was an interruption in the process for some reason.
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade has started.
+
+To move forward from this stage, review the error message and address any problems that it raises.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_MAUTIC_3_MIGRATIONS_FAILED
+******************************
+
+During this stage, the script runs the database migrations required to move between Mautic 2 and Mautic 3.
+
+If an error occurs during this stage, there was a problem with running the migrations, or there was an interruption in the process for some reason.
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade has started.
+
+To move forward from this stage, review the error message and address any problems that it raises.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_RESTORE_USER_DATA_FAILED
+****************************
+
+During this stage, the script restores the user data (Themes/Plugins/Media) from the Mautic 2 backup directory into the new Mautic 3 directory.
+
+If an error occurs during this stage, there was a problem with copying the files and folders, or there was an interruption in the process for some reason.
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade has started.
+
+To move forward from this stage, review the error message and address any problems that it raises.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_BUILD_M3_CACHE
+******************
+
+During this stage, the script builds the Mautic 3 cache to speed up the first load of the new Mautic 3 instance.
+
+If an error occurs during this stage, there was a problem with creating the cache, or there was an interruption in the process for some reason.
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade has started.
+
+To move forward from this stage, review the error message and address any problems that it raises.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.
+
+ERR_CLEANUP_FILES
+*****************
+
+During this stage, the script cleans up the files and folders used during the migration which are no longer needed, completing the migration process.
+
+If an error occurs during this stage, there was a problem with removing the files and folders, or there was an interruption in the process for some reason.
+
+The error message gives you more details about where the problem lies. You can find further information in the ``upgrade_log.txt`` file - created in the root of your Mautic instance when an upgrade has started.
+
+To move forward from this stage, review the error message and address any problems that it raises.
+
+If you need any further help, please post into the dedicated :xref:`Mautic 3 Support Forum`. Please ensure that you provide all the details requested in the post template, which enables the community volunteers to provide effective support.

--- a/docs/mautic_3_upgrade/upgrade_steps.rst
+++ b/docs/mautic_3_upgrade/upgrade_steps.rst
@@ -1,0 +1,119 @@
+
+Mautic 3 upgrade steps
+######################
+
+If you want to know more about all the upgrade steps of the Mautic 3 upgrade process, this is the place to be.
+
+The upgrade process consists of multiple steps to make it as robust as possible. If the process fails at a certain step, you can find all details about the specific error code on the :doc:`upgrade_errors` page.
+
+If you use the web interface to do the upgrade, and you're stuck, you can always go to a specific step by adding the step code to the URL, for example ``upgrade_v3.php#buildCache``. **Please note that manually switching between steps isn't supported, only do so when support asks you to do so**
+
+Pre-upgrade checks
+******************
+
+Code: preUpgradeChecks
+======================
+
+Here, Mautic does some checks prior to starting the upgrade, to make sure your system is compatible with the upgrade. The checks are:
+
+* PHP version must be 7.2 or 7.3
+* MySQL version needs to be >= 5.7.14 or MariaDB >= 10.1
+* Is custom ``api_rate_limiter_cache`` set? 
+* Is Mautic's root directory writable?
+* Are there items in the ``spool/default`` folder? This indicates that there are still Emails in the queue
+* Is the free disk space at least 2x the current Mautic 2 installation?
+* Do you at least have Mautic 2.16.3 installed?
+* Is PHP's ``max_execution_time`` either 0 - unlimited - or > 240? If not, Mautic tries to set it, if that doesn't work, Mautic shows an error
+* Is ``mysqldump`` available for creating database backups?
+* Is there a Mautic 3 upgrade package available for download?
+* Is the ``upgrade temporarily disabled`` switch activated? Mautic's Product Team can enable a switch which shows a warning  that there might be problems with the upgrade. This is only used if there is a major bug with an upgrade path.
+* Are there any custom Plugins installed? If yes, Mautic shows a warning that you should verify if those Plugins are compatible with Mautic 3 or temporarily remove them
+* Get the amount of available database migrations. If that fails, Mautic shows a warning
+* Check if the platform is Windows. If so, Mautic shows a warning that cache creation is significantly slower on this platform and that you should be extra patient.
+* Is PHP's ``memory_limit`` equal to or higher than 256M? If not, Mautic tries to set it, if that doesn't work, Mautic shows an error
+
+1. Start upgrade
+================
+
+Code: startUpgrade
+
+Starts the upgrade and starts logging things as well. In case something goes wrong, you can send your log file on the community support forums so that they can assist further.
+
+2. Database backup
+==================
+
+Code: backupDatabase
+
+If ``mysqldump`` is available, the upgrade script creates a database backup. Especially on shared hosts this function might not be available.
+
+3. Apply Mautic 2 database migrations
+=====================================
+
+Code: applyV2Migrations
+
+During this stage the upgrade script is applying any database migration is that remain outstanding for your Mautic 2.16.x instance. This can sometimes happen if a previous update hasn't completed successfully. It's important that your database has all of the updates required before Mautic can proceed.
+
+4. Download Mautic 3 upgrade package
+====================================
+
+Code: fetchUpdates
+
+In this stage the upgrade script is downloading the Mautic 3 upgrade package from the server.
+
+5. Extract Mautic 3 files
+=========================
+
+Code: extractUpdate
+
+In this stage the upgrade script is extracting the files from the upgrade package and saving them into a folder which Mautic uses for your migration.
+
+6. Back up files and move Mautic 3 files to root
+===============================================================================
+
+Code: moveMautic2and3Files
+
+This is where a lot of magic happens. The upgrade script takes a complete backup of your Mautic 2 installation, after which it moves the Mautic 3 files into place. 
+
+7. Update config/local.php with new configuration parameters
+============================================================
+
+Code: updateLocalConfig
+
+A few configuration parameters have changed in Mautic 3, the upgrade script automatically updates them for you if necessary. To get an overview of all changes configuration parameters, see the :xref:`Mautic 3 Upgrade`.
+
+8. Apply Mautic 3 database migrations
+=====================================
+
+Code: applyMigrations
+
+The database structure has slightly changed in Mautic 3. As part of the standard update process in Mautic, the upgrade script looks for database migrations and executes those.
+
+9. Restore user data
+====================
+
+Code: restoreUserData
+
+If you had any custom Plugins/Themes/Media installed in Mautic 2, this step restores those in Mautic 3 by copying them over to the "new" Mautic 3 folder.
+
+10.  Cleanup
+============
+
+Code: cleanupFiles
+
+In this step, the upgrade script cleans up some of the installation files.
+
+11.  Build Mautic 3 cache
+=========================
+
+Code: buildCache
+
+Mautic always prepares cache the first time you start it, so that it runs faster on subsequent requests. In this step, the upgrade script prepares the cache, so that you'll be able to get started easily and quickly.
+
+12.  Finish
+===========
+
+Code: finished
+
+Cleans up some last files, and allows you to open Mautic 3.
+
+A last step offered at the end of the upgrade is to **remove backup files**. Removing the backup files as soon as possible is strongly recommended. This step also removes the upgrade script itself.


### PR DESCRIPTION
This PR brings over the docs for the Mautic 3 upgrade.

I have pushed it against the 2.x branch as this documentation is only relevant if you're running Mautic 2.