### PR TITLE
Fix xref

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ version = '0.1.0'
 source_suffix = ['.rst', '.md']
 
 extensions = [
+    'xref',
     'sphinx.ext.duration',
     'sphinx.ext.doctest',
     'sphinx.ext.autodoc',

--- a/docs/ext/xref.py
+++ b/docs/ext/xref.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from docutils import nodes
+from sphinx.util import caption_ref_re
+
+def xref( typ, rawtext, text, lineno, inliner, options={}, content=[] ):
+
+    title = target = text
+    titleistarget = True
+    # look if explicit title and target are given with `foo <bar>` syntax
+    brace = text.find('<')
+    if brace != -1:
+        titleistarget = False
+        m = caption_ref_re.match(text)
+        if m:
+            target = m.group(2)
+            title = m.group(1)
+        else:
+            # fallback: everything after '<' is the target
+            target = text[brace+1:]
+            title = text[:brace]
+
+    link = xref.links[target]
+
+    if brace != -1:
+        pnode = nodes.reference(target, title, refuri=link[1])
+    else:
+        pnode = nodes.reference(target, link[0], refuri=link[1])
+
+    return [pnode], []
+
+def get_refs(app):
+
+    xref.links = app.config.xref_links
+
+def setup(app):
+
+    app.add_config_value('xref_links', {}, True)
+    app.add_role('xref', xref)
+    app.connect("builder-inited", get_refs)


### PR DESCRIPTION
We're using this in the developer documentation already. Comes from this Git repo: https://github.com/michaeljones/sphinx-xref

<a href="https://gitpod.io/#https://github.com/mautic/user-documentation/pull/38"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

