### PR TITLE
Exclude links known to wrongly report broken

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,4 +68,6 @@ linkcheck_ignore = [
     r"https://contribute.mautic.org/contributing-to-mautic/tester#setting-up-a-local-testing-environment",
     # Twilio blocks the checker domain-wide.
     r"https://support.twilio.com/*",
+    # This is a demo URL and should not be checked
+    r"https://api-ssl.bitly.com/*",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,3 +58,16 @@ html_theme = 'sphinx_rtd_theme'
 
 # -- Options for EPUB output
 epub_show_urls = 'footnote'
+
+# Please add links here that do not pass the "make checklinks" check.
+# A little context on the reason for ignoring is greatly appreciated!
+linkcheck_ignore = [
+   # Incorrectly reported as 'Anchor "webhooks" not found' so ignoring this
+   'https://docs.mautic.org/en/setup/cron-jobs#webhooks'
+    # Twilio blocks the checker's access to these links
+    'https://support.twilio.com/hc/en-us/articles/223181348-Alphanumeric-Sender-ID-for-Twilio-Programmable-SMS'
+    'https://support.twilio.com/hc/en-us/articles/223183208-Upgrading-to-a-paid-Twilio-Account'
+    'https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID'
+    # Broken anchor link that isn't actually broken
+    'https://contribute.mautic.org/contributing-to-mautic/tester#setting-up-a-local-testing-environment'
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,11 +61,10 @@ epub_show_urls = 'footnote'
 
 # Please add links here that do not pass the "make checklinks" check.
 # A little context on the reason for ignoring is greatly appreciated!
+
+# Anchors are picked up as broken, Twilio blocks the checker domain-wide.
 linkcheck_ignore = [
-   # Incorrectly reported as 'Anchor "webhooks" not found' so ignoring this
    'https://docs.mautic.org/en/setup/cron-jobs#webhooks'
-    # Twilio blocks the checker's access to these links
-    'https://support.twilio.com/*'
-    # Broken anchor link that isn't actually broken
-    'https://contribute.mautic.org/contributing-to-mautic/tester#setting-up-a-local-testing-environment'
+   'https://support.twilio.com/*'
+   'https://contribute.mautic.org/contributing-to-mautic/tester#setting-up-a-local-testing-environment'
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,9 +65,7 @@ linkcheck_ignore = [
    # Incorrectly reported as 'Anchor "webhooks" not found' so ignoring this
    'https://docs.mautic.org/en/setup/cron-jobs#webhooks'
     # Twilio blocks the checker's access to these links
-    'https://support.twilio.com/hc/en-us/articles/223181348-Alphanumeric-Sender-ID-for-Twilio-Programmable-SMS'
-    'https://support.twilio.com/hc/en-us/articles/223183208-Upgrading-to-a-paid-Twilio-Account'
-    'https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID'
+    'https://support.twilio.com/*'
     # Broken anchor link that isn't actually broken
     'https://contribute.mautic.org/contributing-to-mautic/tester#setting-up-a-local-testing-environment'
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,9 +62,10 @@ epub_show_urls = 'footnote'
 # Please add links here that do not pass the "make checklinks" check.
 # A little context on the reason for ignoring is greatly appreciated!
 
-# Anchors are picked up as broken, Twilio blocks the checker domain-wide.
 linkcheck_ignore = [
-   'https://docs.mautic.org/en/setup/cron-jobs#webhooks'
-   'https://support.twilio.com/*'
-   'https://contribute.mautic.org/contributing-to-mautic/tester#setting-up-a-local-testing-environment'
+    # Anchors are picked up as broken
+    r"https://docs.mautic.org/en/setup/cron-jobs#webhooks",
+    r"https://contribute.mautic.org/contributing-to-mautic/tester#setting-up-a-local-testing-environment",
+    # Twilio blocks the checker domain-wide.
+    r"https://support.twilio.com/*",
 ]


### PR DESCRIPTION
This PR adds to the conf.py some links which are consistently causing our GitHub Actions to fail when they do actually work but they are being blocked or have anchors which confuses the GitHub Action.

It is used on the Dev Docs and I hadn't come across it before - it should be really useful!