### PR TITLE
Add detailed instructions on how to make changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,37 @@ We aim to move all aspects of the end-user documentation to Read the Docs.
 
 For more background, our end goal, and to let us know if you want to help, please join the Education Team channel (#t-education) on Slack (get an invite at https://mautic.org/slack). Thanks in advance!
 
+## Making a PR
+
+To make a small change to the base language files for the documentation, use the 'edit file' button on the documentation and commit your changes. This creates a new Pull Request.
+
+To make more complex changes you need to clone this repository and work on your local computer.
+
+1. Install a code editor, we recommend [Visual Studio Code](https://code.visualstudio.com) as this will automatically install all the extensions you need.
+2. Install [Github CLI](https://cli.github.com/) which makes it much easier to work with Git commands
+3. Install the dependencies from the requirements.txt file in the root of the /docs folder using the command `pip3 install -r requirements.txt`
+4. Create a working folder on your local computer
+5. Open a terminal and navigate to that folder using the command `cd <path/to/folder>`
+6. Type `gh repo clone mautic/user-documentation` - you may be prompted to authenticate with GitHub the first time you do this
+7. Open the folder user-documentation that is created in your editor
+8. At the bottom left of your screen you will see the default branch called 'main' is showing as your active branch. Click this, and at the top of the page will show a box where you can select 'create a new branch'. Type a name which relates to the work you plan to do. Once you do this, the bottom left will change from 'main' to the name of the branch you created. At any time you can click back into that, and change back to 'main'.
+9. Now you are working on your own branch for this change, make the changes that you need to make by editing the files, which you should see on the left pane.
+10. Use the Source Control icon on the menu on the left, to view the files you have changed. Click the plus icon next to them to 'stage' them for committing. This allows you to save files in chunks, explaining what you're doing with each chunk, rather than en-mass. It makes it easier to reverse small parts in the future.
+11. If you're making any changes to text, remember to run the commands below to update the files for translations on Transifex and include those in your PR.
+12. Once you've committed all your changes, click the Publish Branch button. This might prompt you to create a fork of the repository - that's fine.
+13. Once you've published the branch, look for the Branches section in the accordion menu under the Source Control icon. Find your branch and hover over the icon which says 'Create pull request' and click it.
+14. This will take you to the web interface of GitHub, where you can give an appropriate title and description for the changes you are proposing.
+15. If you need to make changes in the future after review, switch back to this branch as mentioned in step 8. Make the changes, and then follow steps 9-12. Update the pull request when you have completed your changes and committed and pushed them, to ask the reviewer to re-review after the updates.
+
+### Generating translations files
+
+Currently, we manually create the translation files necessary for Transifex to inform translators that there are changes to the content.
+
+To do this, run the following at the command line after following the steps below to build the documentation locally.
+
+1. Run the command in the /docs folder `sphinx-build -b gettext . docs_translations`
+2. Commit the files created with your pull request
+
 ## Build documentation locally
 
 - [RST Syntax Cheatsheet][RST Cheatsheet]


### PR DESCRIPTION
This PR:

1. Adds more detailed instructions on how to make changes to the docs in the base language, both in the GitHub UI and with VS Code
2. Adds information on how to generate the translation files, which we must start to insist on going forward (and probably need to make a GitHub Action to check for the absence of them / auto-generate them?)