### PR TITLE
Add locale definition for translations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,10 @@ html_theme = 'sphinx_rtd_theme'
 # -- Options for EPUB output
 epub_show_urls = 'footnote'
 
+# -- Internationalisation configuration
+
+locale_dirs = 'locale'
+
 # Please add links here that do not pass the "make checklinks" check.
 # A little context on the reason for ignoring is greatly appreciated!
 


### PR DESCRIPTION
We use a folder called locale and the default is locales - maybe this is why we are not getting the translations detected.

Ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-locale_dirs