### PR TITLE
email_transport queue is now called just email

### DIFF
--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -325,7 +325,7 @@ Mautic works most effectively with high send volumes if you use the queued deliv
 
 .. code-block:: shell
     
-    php /path/to/mautic/bin/console messenger:consume email_transport
+    php /path/to/mautic/bin/console messenger:consume email
 
 Some hosts may have limits on the number of Emails sent during a specified time frame and/or limit the execution time of a script. If that's the case for you, or if you just want to moderate batch processing, you can configure batch numbers and time limits in Mautic's Configuration. See the :doc:`cron job documentation </configuration/cron_jobs>` for more specifics.
 

--- a/docs/configuration/command_line_interface.rst
+++ b/docs/configuration/command_line_interface.rst
@@ -108,7 +108,7 @@ These are the commands you may need to use in relation to your Mautic instance. 
      - Creates the actual column in the table
    * - ``mautic:email:fetch``
      - Fetch and process monitored Email.
-   * - messenger:consume email_transport
+   * - messenger:consume email
      - Processes mail queue
    * - ``mautic:import``
      - If the CSV import is configured to run in background then this command will pick up the pending import jobs and imports the data from CSV files to Mautic.

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -101,7 +101,7 @@ If the system configuration is queueing Emails, a cron job processes them.
 
 .. code-block:: php
 
-    php /path/to/mautic/bin/console messenger:consume email_transport
+    php /path/to/mautic/bin/console messenger:consume email
 
 .. vale off
 

--- a/docs/locale/en_GB/LC_MESSAGES/configuration.po
+++ b/docs/locale/en_GB/LC_MESSAGES/configuration.po
@@ -333,8 +333,8 @@ msgstr ""
 "``mautic:email:fetch``."
 
 #: ../configuration/command_line_interface.rst:107
-msgid "messenger:consume email_transport"
-msgstr "messenger:consume email_transport"
+msgid "messenger:consume email"
+msgstr "messenger:consume email"
 
 #: ../configuration/command_line_interface.rst:108
 msgid "Processes mail queue"


### PR DESCRIPTION
When calling `bin/console messenger:consume email_transport` I'm getting this error:

```
The receiver "email_transport" does not exist. Valid receivers are: email, failed.
```

So it should be just `email`