### PR TITLE
Update references to composer for 5.x version

### DIFF
--- a/docs/getting_started/how_to_install_mautic.rst
+++ b/docs/getting_started/how_to_install_mautic.rst
@@ -35,7 +35,7 @@ Before installing a package, ensure that:
   
 * Your server has enough free disk space to run the installation. Consider the database size as well.
   
-* PHP's `max_execution_time` is at least 240 seconds.
+* PHP's ``max_execution_time`` is at least 240 seconds.
 
 Downloading a production package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -325,14 +325,14 @@ The basic command to use the Recommended Project is:
 
 .. code-block:: shell
 
-  composer create-project mautic/recommended-project:^4 some-dir --no-interaction
+  composer create-project mautic/recommended-project:^5 some-dir --no-interaction
 
 With Composer you can add new dependencies to install along with Mautic:
 
 .. code-block:: shell
 
   cd your-directory
-  composer require mautic/mautic-saelos-bundle:~2.0
+  composer require mautic/mautic/helloworld-bundle
 
 The Composer ``create-project`` command passes ownership of all files to the created project. You should create a new git repository, and commit all files not excluded by the .gitignore file.
 

--- a/docs/getting_started/switching_composer.rst
+++ b/docs/getting_started/switching_composer.rst
@@ -6,7 +6,7 @@ How to switch to Composer
 .. vale on
 
 Until Mautic 4, you could download Mautic as a ZIP file and install it on any PHP server. 
-However, many users were running into installation and update errors, many of which caused considerable frustration and in some cases, significant business disruption. 
+However, many Users were running into installation and update errors, many of which caused considerable frustration and in some cases, significant business disruption. 
 
 In addition, Mautic recently introduced the :ref:`Mautic Marketplace` which isn't compatible with this installation method.
 
@@ -29,7 +29,7 @@ Here's the steps to follow to switch to a Composer-based installation:
 
 #. Go to ``/var/www``
 
-#. Run ``composer create-project mautic/recommended-project:^4 html-new --no-interaction``
+#. Run ``composer create-project mautic/recommended-project:^5 html-new --no-interaction``
 
 #. Copy the following files and folders from ``/var/www/html`` to ``/var/www/html-new``:
 


### PR DESCRIPTION
This PR fixes the Composer version to look for 5.x on the 5.x branch of the docs.