### PR TITLE
Bump RTD Sphinx Search

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@
 # Defining the exact version will make sure things don't break
 sphinx==4.2.0
 sphinx_rtd_theme==1.0.0
-readthedocs-sphinx-search==0.1.0
+readthedocs-sphinx-search==0.3.2
 rstcheck==3.3.1
 myst-parser==0.16.1 
 linkify-it-py==1.0.3


### PR DESCRIPTION
Per the advisory: https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj

We should update the dependency.