### PR TITLE
Update head components section at creating_themes.rst

### DIFF
--- a/docs/builders/creating_themes.rst
+++ b/docs/builders/creating_themes.rst
@@ -80,9 +80,9 @@ Head Components
 
 .. vale on
 
-Mautic processes most of the ``<mj-head>`` components. ``<mj-attributes>`` do not run.
+Mautic processes most of the ``<mj-head>`` components. ``<mj-attributes>`` don't run.
 
-**Tested elements** are: mj-breakpoint, mj-font, mj-html-attributes, mj-style, mj-title, mj-preview 
+**Tested elements** include: ``mj-breakpoint``, ``mj-font``, ``mj-html-attributes``, ``mj-style``, ``mj-title``, and ``mj-preview``.
 
 .. vale off
 

--- a/docs/builders/creating_themes.rst
+++ b/docs/builders/creating_themes.rst
@@ -80,7 +80,9 @@ Head Components
 
 .. vale on
 
-At present, Mautic won't process the ``<mj-head>`` tags. None of the ``<mj-attribuites>`` run, so you have to do all styling inline.
+Mautic processes most of the ``<mj-head>`` components. ``<mj-attributes>`` do not run.
+
+**Tested elements** are: mj-breakpoint, mj-font, mj-html-attributes, mj-style, mj-title, mj-preview 
 
 .. vale off
 


### PR DESCRIPTION
Related issue #247. I since tested all of the [mj-head components](https://documentation.mjml.io/#standard-head-components) by sending real emails through Mautic.

This pr would update the head components section at creating_themes.rst to state that most head components do work, including mj-style.

Previously it stated that none of the head components work, and that all styling has to be inline. This has caused confusion in the past ([Example 1](https://forum.mautic.org/t/are-mj-attributes-functional-on-grapesjs-mjml/21875/5), [Example 2](https://forum.mautic.org/t/grapejs-mjml-still-not-processing-mj-head/29431)), as it did for me as a new Mautic user