### PR TITLE
Update Vale rules to prompt re. published / unpublished no longer being used

### DIFF
--- a/.github/styles/Mautic/FeatureList.yml
+++ b/.github/styles/Mautic/FeatureList.yml
@@ -49,6 +49,8 @@ swap:
   point groups: Point Groups
   plugin: Plugin
   plugins: Plugins
+  publish: Activate or Turn On
+  published: Active or Available
   report: Report
   reports: Reports
   role: Role
@@ -59,6 +61,8 @@ swap:
   stages: Stages
   theme: Theme
   themes: Themes
+  unpublish: Deactivate or Turn Off
+  unpublished: Unavailable or Deactivated
   user: User
   users: Users
   webhook: Webhook


### PR DESCRIPTION
This PR updates the Vale featurelist which prompts people to use the correct terminology.

It encourages them to use Activate / Activated / Turn On or Deactivate / Inactive / Turn Off.