### PR TITLE
clarify messenger:consume params

### DIFF
--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -116,7 +116,7 @@ If the system configuration is queueing Emails, a cron job processes them. If yo
 
 .. code-block:: php
 
-    php /path/to/mautic/bin/console messenger:consume email
+    php /path/to/mautic/bin/console messenger:consume email --time-limit=160
 
 .. vale off
 

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -112,7 +112,7 @@ Process Email queue cron job
 
 .. vale on
 
-If the system configuration queues Emails, a Cron job processes them. If you plan to run `messenger:consume` using a Cron job, you should include at least one of these parameters: `--memory-limit`, `--limit` - the number of emails - or, `--time-limit`; otherwise, the command starts a long-lived process.
+If the system configuration queues Emails, a Cron job processes them. If you plan to run ``messenger:consume`` using a Cron job, you should include at least one of these parameters: ``--memory-limit``, ``--limit`` - the number of emails, or ``--time-limit``. This starts a long-lived process and continues to run without one of these parameters.
 
 .. code-block:: bash
 

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -112,7 +112,7 @@ Process Email queue cron job
 
 .. vale on
 
-If the system configuration queues emails, a cron job processes them. If you plan to run `messenger:consume` using a Cron job, you should include at least one of these parameters: `--memory-limit`, `--limit` (number of emails), or `--time-limit`; otherwise, the command starts a long-lived process.
+If the system configuration queues emails, a cron job processes them. If you plan to run `messenger:consume` using a Cron job, you should include at least one of these parameters: `--memory-limit`, `--limit` - the number of emails - or, `--time-limit`; otherwise, the command starts a long-lived process.
 
 .. code-block:: php
 

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -112,7 +112,7 @@ Process Email queue cron job
 
 .. vale on
 
-If the system configuration is queueing Emails, a cron job processes them.
+If the system configuration is queueing Emails, a cron job processes them. If you plan to run `messenger:consume` on a cron you should include, at minimum one of these parameters `--memory-limit`, `--limit` (number of emails), `--time-limit` otherwise, this will start up a long-lived process.
 
 .. code-block:: php
 

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -112,7 +112,7 @@ Process Email queue cron job
 
 .. vale on
 
-If the system configuration queues emails, a cron job processes them. If you plan to run `messenger:consume` using a Cron job, you should include at least one of these parameters: `--memory-limit`, `--limit` - the number of emails - or, `--time-limit`; otherwise, the command starts a long-lived process.
+If the system configuration queues Emails, a Cron job processes them. If you plan to run `messenger:consume` using a Cron job, you should include at least one of these parameters: `--memory-limit`, `--limit` - the number of emails - or, `--time-limit`; otherwise, the command starts a long-lived process.
 
 .. code-block:: php
 

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -112,7 +112,7 @@ Process Email queue cron job
 
 .. vale on
 
-If the system configuration is queueing Emails, a cron job processes them. If you plan to run `messenger:consume` on a cron you should include, at minimum one of these parameters `--memory-limit`, `--limit` (number of emails), `--time-limit` otherwise, this will start up a long-lived process.
+If the system configuration queues emails, a cron job processes them. If you plan to run `messenger:consume` using a Cron job, you should include at least one of these parameters: `--memory-limit`, `--limit` (number of emails), or `--time-limit`; otherwise, the command starts a long-lived process.
 
 .. code-block:: php
 

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -114,7 +114,7 @@ Process Email queue cron job
 
 If the system configuration queues Emails, a Cron job processes them. If you plan to run `messenger:consume` using a Cron job, you should include at least one of these parameters: `--memory-limit`, `--limit` - the number of emails - or, `--time-limit`; otherwise, the command starts a long-lived process.
 
-.. code-block:: php
+.. code-block:: bash
 
     php /path/to/mautic/bin/console messenger:consume email --time-limit=160
 


### PR DESCRIPTION
If this process is setup on a cron, depending on the frequency of the cron, this will cause an OOM situation over time since the process will never exit