### PR TITLE
Add documentation for contact field label modifier

### DIFF
--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -156,7 +156,7 @@ This is useful when your select fields store technical values but you want to di
 - A country select field storing ``us`` can display ``United States``
 - A boolean field storing ``1`` can display ``Yes``
 
-The modifier also works with company fields:
+The modifier also works with Company fields:
 
 .. code-block:: php
 

--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -141,6 +141,28 @@ To use custom date fields in tokens, use the following format:
 
 The date outputs in a human-readable format, configured in the settings in your Global Configuration > System Settings under 'Default format for date only' and 'Default time only format'.
 
+Label modifier for select and boolean fields
+---------------------------------------------
+
+For select and boolean field types, you can display the human-readable label instead of the stored value by using the ``|label`` modifier:
+
+.. code-block:: php
+
+    {contactfield=select_alias|label}
+    {contactfield=bool_alias|label}
+
+This is useful when your select fields store technical values but you want to display user-friendly labels in your Emails. For example:
+
+- A country select field storing ``us`` can display ``United States``
+- A boolean field storing ``1`` can display ``Yes``
+
+The modifier also works with company fields:
+
+.. code-block:: php
+
+    {contactfield=company_select_alias|label}
+    {contactfield=company_bool_alias|label}
+
 Contact replies
 ===============
 

--- a/docs/configuration/variables.rst
+++ b/docs/configuration/variables.rst
@@ -36,8 +36,8 @@ For a boolean field with alias ``is_subscriber``:
 
 This modifier works for both Contact fields and Company fields:
 
-- ``{contactfield=company_type|label}`` - displays the label of a company select field
-- ``{contactfield=company_active|label}`` - displays the label of a company boolean field
+- ``{contactfield=company_type|label}`` - displays the label of a Company select field
+- ``{contactfield=company_active|label}`` - displays the label of a Company boolean field
 
 .. note::
     The ``|label`` modifier only works with select and boolean field types. For other field types, it will display the regular value.

--- a/docs/configuration/variables.rst
+++ b/docs/configuration/variables.rst
@@ -8,6 +8,40 @@ Variables
 
   ``Hi {contactfield=firstname|there},``
 
+Token modifiers
+***************
+
+Label modifier for select and boolean fields
+=============================================
+
+For select and boolean type fields, you can use the ``|label`` modifier to display the human-readable label instead of the stored value. This is particularly useful when your select fields store values like codes or IDs but you want to display friendly labels to your Contacts.
+
+**Syntax:**
+
+.. code-block:: text
+
+    {contactfield=field_alias|label}
+
+**Examples:**
+
+For a select field with alias ``country_select`` that has options like ``us`` (United States), ``uk`` (United Kingdom):
+
+- ``{contactfield=country_select}`` - displays the value: ``us``
+- ``{contactfield=country_select|label}`` - displays the label: ``United States``
+
+For a boolean field with alias ``is_subscriber``:
+
+- ``{contactfield=is_subscriber}`` - displays the value: ``1`` or ``0``
+- ``{contactfield=is_subscriber|label}`` - displays the label: ``Yes`` or ``No``
+
+This modifier works for both Contact fields and Company fields:
+
+- ``{contactfield=company_type|label}`` - displays the label of a company select field
+- ``{contactfield=company_active|label}`` - displays the label of a company boolean field
+
+.. note::
+    The ``|label`` modifier only works with select and boolean field types. For other field types, it will display the regular value.
+
 Contact fields
 **************
 


### PR DESCRIPTION
## Description
This PR adds documentation for the new ` < /dev/null | label` modifier that allows displaying human-readable labels for select and boolean contact fields instead of their stored values.

## Changes
- Added new "Token modifiers" section in `/docs/configuration/variables.rst` explaining the label modifier syntax
- Added subsection in `/docs/channels/emails.rst` under Tokens section with examples
- Included examples for both contact and company fields

## Examples documented
- Contact select field: `{contactfield=select_alias|label}`
- Contact boolean field: `{contactfield=bool_alias|label}`
- Company select field: `{contactfield=company_select_alias|label}`
- Company boolean field: `{contactfield=company_bool_alias|label}`

## Related PR
Related to https://github.com/mautic/mautic/pull/12620