### PR TITLE
Remove update command from 5.x docs

### DIFF
--- a/docs/getting_started/how_to_update_mautic.rst
+++ b/docs/getting_started/how_to_update_mautic.rst
@@ -108,7 +108,6 @@ Follow the steps below to update your core files.
     bin/console cache:clear
     bin/console mautic:update:apply --finish
     bin/console doctrine:migration:migrate --no-interaction
-    bin/console doctrine:schema:update --no-interaction --force
     bin/console cache:clear
 
 Updating in the browser


### PR DESCRIPTION
## Description

This PR removes the `bin/console doctrine:schema:update --no-interaction --force` from `5.x` docs with link below:

https://docs.mautic.org/en/5.x/getting_started/how_to_update_mautic.html#updating-mautic-composer-based-installs

## Linked Issue

Relates to #399 

