### PR TITLE
Remove update command from 4.x docs

### DIFF
--- a/docs/getting_started/how_to_install_mautic.rst
+++ b/docs/getting_started/how_to_install_mautic.rst
@@ -382,7 +382,6 @@ Follow the steps below to update your core files.
   bin/console cache:clear 
   bin/console mautic:update:apply --finish 
   bin/console doctrine:migration:migrate --no-interaction 
-  bin/console doctrine:schema:update --no-interaction --force 
   bin/console cache:clear
 
 .. vale off


### PR DESCRIPTION
## Description

This PR removes the `bin/console doctrine:schema:update --no-interaction --force` from `4.x` docs with link below:

https://docs.mautic.org/en/4.x/getting_started/how_to_install_mautic.html#updating-mautic-core

## Linked Issue

Relates to #399 

