### PR TITLE
Fix invisible text in sidebar version dropdown options

### DIFF
--- a/docs/css/theme.css
+++ b/docs/css/theme.css
@@ -13,3 +13,7 @@ a {
 .wy-menu-vertical a, .wy-side-nav-search>a {
     color: #ffffff;
 }
+
+.wy-side-nav-search .version-switch select option {
+    color: #404040;
+}


### PR DESCRIPTION
## Description

The version switcher in the sidebar had white text on a white background, making options invisible until hovered. 

This PR sets the `<option>` text color to #404040 for better readability.

<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->

Before

<img width="506" height="354" alt="image" src="https://github.com/user-attachments/assets/ebc768d6-31b8-456f-a52f-90d3231d85f4" />

After

<img width="492" height="358" alt="image" src="https://github.com/user-attachments/assets/9bf25604-3a09-466d-8517-01408ab69675" />
