### PR TITLE
fixed the campaign builder link for v6.0

### DIFF
--- a/docs/campaigns/creating_campaigns.rst
+++ b/docs/campaigns/creating_campaigns.rst
@@ -54,7 +54,7 @@ To begin creating Campaigns, perform the following steps:
 -  **Active** - Click the toggle switch to turn the Campaign on or off. Ensure that you don't activate a Campaign until you're actually ready for it to go live. You can also schedule to activate or deactivate a Campaign at a future date by selecting a time and date.
 
 #. Click **Launch Campaign Builder** to start building your Campaign, and add at least one event. For information about how to use the
-   Campaign Builder, see :doc:`/campaigns/creating_campaigns`.
+   Campaign Builder, see :doc:`/campaigns/campaign_builder`.
 
 #. After adding events to your Campaign, close the Campaign Builder and
    click **Save & Close** to save your changes.


### PR DESCRIPTION
## Description

fixed the campaign builder link in v6.0 to now correctly point to the using the campaign builder page

docs -> campaign -> creating_campaigns

## Linked issue

Closes #505

## Screenshots or screen recordings

https://github.com/user-attachments/assets/98c4afe0-6b40-4799-bbcf-bcce9fc0f833
