### PR TITLE
fixed the campaign builder link in v6.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "hostname": "0.0.0.0",
+            "port": 9003,
+            "pathMappings": {
+                "/var/www/html": "${workspaceFolder}"
+            },
+            "preLaunchTask": "DDEV: Enable Xdebug",
+            "postDebugTask": "DDEV: Disable Xdebug"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "DDEV: Enable Xdebug",
+			"type": "shell",
+			"command": "ddev xdebug on",
+			"presentation": {
+				"reveal": "silent",
+				"close": true
+			}
+		},
+		{
+			"label": "DDEV: Disable Xdebug",
+			"type": "shell",
+			"command": "ddev xdebug off",
+			"presentation": {
+				"reveal": "silent",
+				"close": true
+			}
+		}
+	]
+}

--- a/docs/campaigns/creating_campaigns.rst
+++ b/docs/campaigns/creating_campaigns.rst
@@ -53,8 +53,7 @@ To begin creating Campaigns, perform the following steps:
 -  **Allow Contacts to restart the Campaign** - Click the toggle switch to allow Contacts to restart the Campaign if you're building a Campaign for a recurring message - for example birthdays, subscriptions - or transactional operations - for example activity notifications, updating data. Enabling this option allows Contacts to go through the same Campaign multiple times.
 -  **Active** - Click the toggle switch to turn the Campaign on or off. Ensure that you don't activate a Campaign until you're actually ready for it to go live. You can also schedule to activate or deactivate a Campaign at a future date by selecting a time and date.
 
-#. Click **Launch Campaign Builder** to start building your Campaign, and add at least one event. For information about how to use the
-   Campaign Builder, see :doc:`/campaigns/creating_campaigns`.
+#. Click **Launch Campaign Builder** to start building your Campaign, and add at least one event. For information about how to use the Campaign Builder, see :doc:`/campaigns/campaign_builder`.
 
 #. After adding events to your Campaign, close the Campaign Builder and
    click **Save & Close** to save your changes.

--- a/docs/campaigns/creating_campaigns.rst
+++ b/docs/campaigns/creating_campaigns.rst
@@ -54,7 +54,7 @@ To begin creating Campaigns, perform the following steps:
 -  **Active** - Click the toggle switch to turn the Campaign on or off. Ensure that you don't activate a Campaign until you're actually ready for it to go live. You can also schedule to activate or deactivate a Campaign at a future date by selecting a time and date.
 
 #. Click **Launch Campaign Builder** to start building your Campaign, and add at least one event. For information about how to use the
-   Campaign Builder, see :doc:`/campaigns/creating_campaigns`.
+   Campaign Builder, see :doc:`/campaigns/campaign_builder`.
 
 #. After adding events to your Campaign, close the Campaign Builder and
    click **Save & Close** to save your changes.


### PR DESCRIPTION
## Description

fixed the campaign builder link in v6.0 to now correctly point to the using the campaign builder page

docs -> campaign -> creating_campaigns

## Linked issue

Closes #505

## Screenshots or screen recordings

https://github.com/user-attachments/assets/c38b2898-cd56-4f78-97ac-4ed51b11c5e4
