### PR TITLE
fix: Broken links to the outdated developer docs URL

### DIFF
--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -120,7 +120,7 @@ API settings
   :width: 600
   :alt: Screenshot showing API Settings Configuration in Mautic
 
-Full API documentation is available :xref:`Mautic developer API`.
+Complete API documentation is available on the :xref:`Mautic REST API` section in the Developer Documentation.
 
 * **API enabled** - Select Yes to pass data in and out of Mautic through the API.
 

--- a/docs/contacts/manage_contacts.rst
+++ b/docs/contacts/manage_contacts.rst
@@ -355,7 +355,7 @@ Website monitoring
 
 It's possible to use Mautic to monitor all traffic on a website by loading a JavaScript file - recommended - or by adding a tracking pixel to resources. It's important to note that traffic isn't monitored from logged-in Mautic Users. To verify that the JavaScript/pixel is working, use an incognito or private browsing window or log out of Mautic prior to testing.
 
-Note that by default, Mautic won't track traffic originating from the same :xref:`private network` as itself, but you can configure Mautic to track this internal traffic by setting the ``track_private_ip_ranges`` configuration option to ``true`` in ``app/config/local.php`` then and then :xref:`clearing the symfony cache`.
+Note that by default, Mautic won't track traffic originating from the same :xref:`private network` as itself, but you can configure Mautic to track this internal traffic by setting the ``track_private_ip_ranges`` configuration option to ``true`` in ``app/config/local.php`` and clearing the :xref:`symfony cache`.
 
 .. vale off
 

--- a/docs/links/clear_cache.py
+++ b/docs/links/clear_cache.py
@@ -1,7 +1,0 @@
-from . import link
-
-link_name = "clearing the symfony cache" 
-link_text = "clearing the Symfony cache" 
-link_url = "https://developer.mautic.org/#cache" 
-
-link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/marketplace.py
+++ b/docs/links/marketplace.py
@@ -1,7 +1,0 @@
-from . import link
-
-link_name = "Developer Documentation Marketplace" 
-link_text = "Developer Documentation Marketplace" 
-link_url = "https://developer.mautic.org/#marketplace" 
-
-link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_api_documentation.py
+++ b/docs/links/mautic_api_documentation.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Reports API documentation" 
 link_text = "Reports API documentation" 
-link_url = "https://developer.mautic.org/#reports" 
+link_url = "https://devdocs.mautic.org/en/5.x/components/reports.html" 
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_clear_cache_docs.py
+++ b/docs/links/mautic_clear_cache_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "symfony cache" 
+link_text = "Symfony cache" 
+link_url = "https://devdocs.mautic.org/en/5.x/components/cache.html" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_developer_api_section.py
+++ b/docs/links/mautic_developer_api_section.py
@@ -1,7 +1,7 @@
 from . import link
 
-link_name = "Mautic developer API" 
-link_text = "in the Developer Documentation" 
-link_url = "https://developer.mautic.org/#rest-api" 
+link_name = "Mautic REST API"
+link_text = "REST API"
+link_url = "https://devdocs.mautic.org/en/5.x/rest_api/assets.html"
 
 link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_marketplace_docs.py
+++ b/docs/links/mautic_marketplace_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Marketplace"
+link_text = "Marketplace"
+link_url = "https://devdocs.mautic.org/en/5.x/marketplace/getting_started.html"
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_plugins_documentation.py
+++ b/docs/links/mautic_plugins_documentation.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mautic Plugins" 
+link_text = "Plugins" 
+link_url = "https://devdocs.mautic.org/en/5.x/plugins/getting_started.html" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_roles_api_docs.py
+++ b/docs/links/mautic_roles_api_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Roles using the API"
+link_text = "Roles using the API"
+link_url = "https://github.com/mautic/developer-documentation/blob/main/source/includes/_api_endpoint_roles.md"
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_theme_directory_structure_docs.py
+++ b/docs/links/mautic_theme_directory_structure_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Themes directory structure"
+link_text = "Themes directory structure"
+link_url = "https://devdocs.mautic.org/en/5.x/themes/getting_started.html#directory-structure"
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mautic_theme_docs.py
+++ b/docs/links/mautic_theme_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Themes"
+link_text = "Themes"
+link_url = "https://devdocs.mautic.org/en/5.x/themes/getting_started.html"
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/plugins_documentation.py
+++ b/docs/links/plugins_documentation.py
@@ -1,7 +1,0 @@
-from . import link
-
-link_name = "Plugins developer documentation" 
-link_text = "Plugins developer documentation" 
-link_url = "https://developer.mautic.org/#plugins" 
-
-link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/roles_api.py
+++ b/docs/links/roles_api.py
@@ -1,9 +1,0 @@
-
-
-from . import link
-
-link_name = "create Roles using the API" 
-link_text = "create Roles using the API" 
-link_url = "https://developer.mautic.org/#roles" 
-
-link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/theme.py
+++ b/docs/links/theme.py
@@ -1,7 +1,0 @@
-from . import link
-
-link_name = "create a Theme" 
-link_text = "create a Theme" 
-link_url = "https://developer.mautic.org/#themes" 
-
-link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/theme_directory_structure.py
+++ b/docs/links/theme_directory_structure.py
@@ -1,7 +1,0 @@
-from . import link
-
-link_name = "themes developer documentation"
-link_text = "themes developer documentation"
-link_url = "https://developer.mautic.org/#theme-directory-structure"
-
-link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/marketplace/marketplace.rst
+++ b/docs/marketplace/marketplace.rst
@@ -9,7 +9,7 @@ Mautic Marketplace
 
     The current Marketplace version doesn't verify Mautic version compatibility of Plugins yet, as this requires a change in each existing Plugin.
 
-    Please don't blindly manually install Plugins you see in the Mautic Marketplace, as they may not work with your version of Mautic. Always verify if they support your Mautic version before installing. Developers can refer to the :xref:`Developer Documentation Marketplace` for how to make your Plugin compatible with the Mautic Marketplace.
+    Please don't blindly manually install Plugins you see in the Mautic Marketplace, as they may not work with your version of Mautic. Always verify if they support your Mautic version before installing. Developers can refer to the :xref:`Marketplace` section in the Developer Documentation for how to make your Plugin compatible with the Mautic Marketplace.
 
 .. vale off
 
@@ -191,4 +191,4 @@ How to get your Plugin listed on the Mautic Marketplace
 
 .. vale on
 
-Please review the resources on the :xref:`Developer Documentation Marketplace` for more information.
+Please review the resources on the :xref:`Marketplace` section in the Developer Documentation for more information.

--- a/docs/plugins/plugin_resources.rst
+++ b/docs/plugins/plugin_resources.rst
@@ -1,7 +1,7 @@
 Plugin resources
 ################
 
-Mautic Plugins are installable packages which can extend Mautic feature or integrate it with another system. You can find more information about how to create a Mautic Plugin in the :xref:`Plugins developer documentation`. 
+Mautic Plugins are installable packages which can extend Mautic feature or integrate it with another system. You can find more information about how to create a Mautic Plugin on the :xref:`Mautic Plugins` section in the Developer Documentation.
 
 You can find the Plugins in the right Admin menu.
 

--- a/docs/themes/customizing_themes.rst
+++ b/docs/themes/customizing_themes.rst
@@ -14,18 +14,4 @@ Customizing an existing Theme
 
 .. vale on
 
-To customize the downloaded Theme, review the :xref:`themes developer documentation` for detailed guidance.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+To customize the downloaded Theme, review the :xref:`Themes directory structure` section in the Developer Documentation for detailed guidance.

--- a/docs/themes/manage_themes.rst
+++ b/docs/themes/manage_themes.rst
@@ -9,7 +9,7 @@ Themes control the look and feel of the Mautic Landing Pages, Emails, Forms and 
 
 A basic Mautic installation comes pre-packaged with a number of Themes for you to use 'as-is' or adapt to suit specific projects. 
 
-It's also possible to :xref:`create a Theme` for Mautic from scratch.
+It's also possible to create :xref:`Themes` for Mautic from scratch.
 
 Access the Theme Manager via the Admin Menu. Click the cog icon in the top right corner to open it and select the Theme menu item.
 
@@ -38,7 +38,7 @@ Installing a Theme
 
 .. vale on
 
-It's necessary to install a new or edited Theme as a zip package. The zip package must have the same structure as the preinstalled Themes and the config.json file must be present in the root folder of the zip package. The :xref:`themes developer documentation` contains more on that.
+It's necessary to install a new or edited Theme as a zip package. The zip package must have the same structure as the preinstalled Themes and the ``config.json`` file must be present in the root folder of the zip package. The :xref:`Themes directory structure` section in the Developer Documentation contains more information about that.
 
 .. note:: 
 
@@ -148,7 +148,7 @@ To download a Theme:
 
 5. Select the drop-down before the Theme, and click **Download**.
 
-Upon downloading a Theme on your local machine, you can modify it following the structure outlined in the :xref:`create a Theme` section of the Developer Documentation before reinstalling it for use in your instance.
+Upon downloading a Theme on your local machine, you can modify it following the structure outlined in the :xref:`Themes` section of the Developer Documentation before reinstalling it for use in your instance.
 
 .. vale off
 

--- a/docs/themes/theme_structure.rst
+++ b/docs/themes/theme_structure.rst
@@ -5,4 +5,4 @@ Theme Structure
 
 .. vale on
 
-Visit the :xref:`themes developer documentation` about Themes for details about the Theme structure.
+Visit the :xref:`Themes directory structure` section in the Developer Documentation for more details.

--- a/docs/users_roles/managing_roles.rst
+++ b/docs/users_roles/managing_roles.rst
@@ -100,4 +100,4 @@ Since Mautic 5.1 there is an additional permission relating to allowing Users of
   
   For example, if a User's Role doesn't have Asset permissions, they can't create or view widgets on the dashboard for Asset data.
 
-You can also :xref:`create Roles using the API`.
+You can also create :xref:`Roles using the API`.


### PR DESCRIPTION
## Description

This PR fixes broken links to the outdated developer docs URL with the following changes:

1. Changed links from the old dev docs URL to the new one when they're available. If they're not available, the links go to the files in the legacy GitHub repository (https://github.com/mautic/developer-documentation/tree/main/source/includes)
2. Change some `link_name` and `link_text`, and adjust wording for better read.
3. Renamed some files by appending "mautic" for clarity and better search.

<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue

Closes #566 


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->