### PR TITLE
Docs: Change Roles page link and fix a broken link in branch 7.1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,4 +97,6 @@ linkcheck_ignore = [
     r"https://dev.mysql.com/doc/refman/5.7/en/regexp.html",
     # 400 client error from this domain
     r"https://developers.facebook.com/products/facebook-login/",
+    # 403 client error from this domain
+    r"https://www.vtiger.com/",
 ]

--- a/docs/links/mautic_roles_api_docs.py
+++ b/docs/links/mautic_roles_api_docs.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "Roles using the API"
 link_text = "Roles using the API"
-link_url = "https://github.com/mautic/developer-documentation/blob/main/source/includes/_api_endpoint_roles.md"
+link_url = "https://devdocs.mautic.org/en/5.x/rest_api/roles.html"
 
 link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
## Description

This PR changes the Roles page link from https://github.com/mautic/developer-documentation/blob/main/source/includes/_api_endpoint_roles.md to https://devdocs.mautic.org/en/5.x/rest_api/roles.html in branch 7.1.

It also fixes a 403 broken link.


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue

Closes #577 


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->