### PR TITLE
Cherry-pick: "Add documentation for contact field label modifier" to 7.1

### DIFF
--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -187,6 +187,28 @@ To use custom date fields in tokens, use the following format:
 
 The date outputs in a human-readable format, configured in the settings in your Global Configuration > System Settings under 'Default format for date only' and 'Default time only format'.
 
+Label modifier for select and boolean fields
+---------------------------------------------
+
+For select and boolean field types, you can display the human-readable label instead of the stored value by using the ``|label`` modifier:
+
+.. code-block:: php
+
+    {contactfield=select_alias|label}
+    {contactfield=bool_alias|label}
+
+This is useful when your select fields store technical values but you want to display user-friendly labels in your Emails. For example:
+
+- A country select field storing ``us`` can display ``United States``
+- A boolean field storing ``1`` can display ``Yes``
+
+The modifier also works with company fields:
+
+.. code-block:: php
+
+    {contactfield=company_select_alias|label}
+    {contactfield=company_bool_alias|label}
+
 Contact replies
 ===============
 

--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -202,7 +202,7 @@ This is useful when your select fields store technical values but you want to di
 - A country select field storing ``us`` can display ``United States``
 - A boolean field storing ``1`` can display ``Yes``
 
-The modifier also works with company fields:
+The modifier also works with Company fields:
 
 .. code-block:: php
 

--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -188,26 +188,26 @@ To use custom date fields in tokens, use the following format:
 The date outputs in a human-readable format, configured in the settings in your Global Configuration > System Settings under 'Default format for date only' and 'Default time only format'.
 
 Label modifier for select and boolean fields
----------------------------------------------
+--------------------------------------------
 
 For select and boolean field types, you can display the human-readable label instead of the stored value by using the ``|label`` modifier:
 
 .. code-block:: php
 
-    {contactfield=select_alias|label}
-    {contactfield=bool_alias|label}
+   {contactfield=select_alias|label}
+   {contactfield=bool_alias|label}
 
-This is useful when your select fields store technical values but you want to display user-friendly labels in your Emails. For example:
+This is particularly useful when these fields contain technical values, but you want to show user-friendly labels in your Emails. For instance:
 
-- A country select field storing ``us`` can display ``United States``
-- A boolean field storing ``1`` can display ``Yes``
+* A country selection field storing ``us`` can display ``United States``
+* A boolean field storing ``1`` can display ``Yes``
 
 The modifier also works with Company fields:
 
 .. code-block:: php
 
-    {contactfield=company_select_alias|label}
-    {contactfield=company_bool_alias|label}
+   {contactfield=company_select_alias|label}
+   {contactfield=company_bool_alias|label}
 
 Contact replies
 ===============

--- a/docs/configuration/variables.rst
+++ b/docs/configuration/variables.rst
@@ -36,8 +36,8 @@ For a boolean field with alias ``is_subscriber``:
 
 This modifier works for both Contact fields and Company fields:
 
-- ``{contactfield=company_type|label}`` - displays the label of a company select field
-- ``{contactfield=company_active|label}`` - displays the label of a company boolean field
+- ``{contactfield=company_type|label}`` - displays the label of a Company select field
+- ``{contactfield=company_active|label}`` - displays the label of a Company boolean field
 
 .. note::
     The ``|label`` modifier only works with select and boolean field types. For other field types, it will display the regular value.

--- a/docs/configuration/variables.rst
+++ b/docs/configuration/variables.rst
@@ -12,35 +12,36 @@ Token modifiers
 ***************
 
 Label modifier for select and boolean fields
-=============================================
+============================================
 
-For select and boolean type fields, you can use the ``|label`` modifier to display the human-readable label instead of the stored value. This is particularly useful when your select fields store values like codes or IDs but you want to display friendly labels to your Contacts.
+For select and boolean type fields, you can use the ``|label`` modifier to display the human-readable label instead of the stored value. It's beneficial when your select fields store values like codes or IDs, but you want to display friendly labels to your Contacts.
 
 **Syntax:**
 
 .. code-block:: text
 
-    {contactfield=field_alias|label}
+   {contactfield=field_alias|label}
 
 **Examples:**
 
-For a select field with alias ``country_select`` that has options like ``us`` (United States), ``uk`` (United Kingdom):
+* For a select field with alias ``country_select`` that has options, such as ``us`` for ``United States`` or ``uk`` for ``United Kingdom``:
 
-- ``{contactfield=country_select}`` - displays the value: ``us``
-- ``{contactfield=country_select|label}`` - displays the label: ``United States``
+   * ``{contactfield=country_select}`` displays the value ``us``
+   * ``{contactfield=country_select|label}`` displays the label ``United States``
 
-For a boolean field with alias ``is_subscriber``:
+* For a boolean field with alias ``is_subscriber``:
 
-- ``{contactfield=is_subscriber}`` - displays the value: ``1`` or ``0``
-- ``{contactfield=is_subscriber|label}`` - displays the label: ``Yes`` or ``No``
+   * ``{contactfield=is_subscriber}`` displays the value ``1`` or ``0``
+   * ``{contactfield=is_subscriber|label}`` displays the label ``Yes`` or ``No``
 
-This modifier works for both Contact fields and Company fields:
+* For both Contact fields and Company fields:
 
-- ``{contactfield=company_type|label}`` - displays the label of a Company select field
-- ``{contactfield=company_active|label}`` - displays the label of a Company boolean field
+   * ``{contactfield=company_type|label}`` displays the label of a Company select field
+   * ``{contactfield=company_active|label}`` displays the label of a Company boolean field
 
 .. note::
-    The ``|label`` modifier only works with select and boolean field types. For other field types, it will display the regular value.
+
+   The ``|label`` modifier only works with select and boolean field types. For other field types, it displays the regular value.
 
 Contact fields
 **************

--- a/docs/configuration/variables.rst
+++ b/docs/configuration/variables.rst
@@ -8,6 +8,40 @@ Variables
 
   ``Hi {contactfield=firstname|there},``
 
+Token modifiers
+***************
+
+Label modifier for select and boolean fields
+=============================================
+
+For select and boolean type fields, you can use the ``|label`` modifier to display the human-readable label instead of the stored value. This is particularly useful when your select fields store values like codes or IDs but you want to display friendly labels to your Contacts.
+
+**Syntax:**
+
+.. code-block:: text
+
+    {contactfield=field_alias|label}
+
+**Examples:**
+
+For a select field with alias ``country_select`` that has options like ``us`` (United States), ``uk`` (United Kingdom):
+
+- ``{contactfield=country_select}`` - displays the value: ``us``
+- ``{contactfield=country_select|label}`` - displays the label: ``United States``
+
+For a boolean field with alias ``is_subscriber``:
+
+- ``{contactfield=is_subscriber}`` - displays the value: ``1`` or ``0``
+- ``{contactfield=is_subscriber|label}`` - displays the label: ``Yes`` or ``No``
+
+This modifier works for both Contact fields and Company fields:
+
+- ``{contactfield=company_type|label}`` - displays the label of a company select field
+- ``{contactfield=company_active|label}`` - displays the label of a company boolean field
+
+.. note::
+    The ``|label`` modifier only works with select and boolean field types. For other field types, it will display the regular value.
+
 Contact fields
 **************
 


### PR DESCRIPTION
## Description

This PR cherry-picks https://github.com/mautic/user-documentation/pull/395 into the 7.1 branch.

It also:

- Adds documentation for the new | label modifier:

   - https://github.com/mautic/mautic/pull/12620

- Fixes format and adjust wordings for readabilty


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->