### PR TITLE
docs(email): document global defaults for preference center and UTM tracking

### DIFF
--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -380,7 +380,19 @@ Message settings
 * **Convert embed images to Base64** - Select **Yes** to display embedded images in Emails using embedded base64 code rather than as embedded images.
 
 * **Disable trackable URLs** - Removes tracking from URLs in your Emails. Select Yes to prevent tracking, reporting on, and using decisions based on link clicks. Some Email service providers don't like redirecting URLs. Using trackable URLs in your Emails may impact deliverability.
-  
+
+* **Default UTM source** - Sets a site-wide default ``utm_source`` value that pre-populates the UTM source field when creating a new Email. Existing Emails and cloned Emails retain their own values. Leave blank to use no default.
+
+* **Default UTM medium** - Sets a site-wide default ``utm_medium`` value that pre-populates the UTM medium field when creating a new Email. Existing Emails and cloned Emails retain their own values. Leave blank to use no default.
+
+* **Default UTM campaign** - Sets a site-wide default ``utm_campaign`` value that pre-populates the UTM campaign field when creating a new Email. Existing Emails and cloned Emails retain their own values. Leave blank to use no default.
+
+* **Default UTM content** - Sets a site-wide default ``utm_content`` value that pre-populates the UTM content field when creating a new Email. Existing Emails and cloned Emails retain their own values. Leave blank to use no default.
+
+.. note::
+
+  These defaults only apply when creating a **new** Email. Editing an existing Email or cloning an Email never overwrites the values already on that Email — even if those fields are blank on the clone source.
+
 Unsubscribe settings
 ====================
 
@@ -405,6 +417,8 @@ Unsubscribe settings
 * **Show Contact's Categories** - If you have Categories set for Contacts, Campaigns, Emails, etc., select Yes to allow the Contact to opt out of the Categories they choose from the Preference Center page.
 
 * **Show Contact's preferred Channel option** - If you have multiple Channels available within your Mautic instance. For example; Email, ``SMS``, mobile push, web notifications, etc., Contacts can choose their preferred Channel. This can be useful if you are using the Marketing Messages feature of Mautic. More information about the Preference Center is available :doc:`here</contacts/preference_center>`.
+
+* **Default Preference Center page** - Select a Landing Page to use as the Preference Center for new Emails. When creating a new Email, this page pre-populates the Preference Center field. Editing an existing Email or cloning an Email does not change that Email's Preference Center — even if the clone source has no Preference Center set. For more information on configuring the Preference Center, see :doc:`here</contacts/preference_center>`.
 
 
 .. vale off


### PR DESCRIPTION
## Summary

Documents the five new **Configuration → Email** settings introduced in mautic/mautic#15905:

- **Default UTM source, medium, campaign, content** — added to the *Message settings* section
- **Default Preference Center page** — added to the *Unsubscribe settings* section

When a new Email is created, these site-wide defaults pre-populate the relevant fields. Existing Emails, edited Emails, and cloned Emails always retain their own explicit values.

## Changes

- `docs/configuration/settings.rst` — two additions matching the UI layout from the code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)