### PR TITLE
update link to themes in developer docs to new endpoint

### DIFF
--- a/docs/links/mautic_getting_started_with_themes_docs.py
+++ b/docs/links/mautic_getting_started_with_themes_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Getting started with Themes"
+link_text = "Getting started with Themes"
+link_url = "https://devdocs.mautic.org/en/5.x/themes/getting_started.html"
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/themes/theme_structure.rst
+++ b/docs/themes/theme_structure.rst
@@ -5,4 +5,4 @@ Theme Structure
 
 .. vale on
 
-Visit the :xref:`Themes directory structure` section in the Developer Documentation for more details.
+Visit the :xref:`Getting started with Themes` section in the Developer Documentation for more details.


### PR DESCRIPTION
## Description

The link to the Themes developer documentation in the user docs points to the old endpoint of Themes `directory structure` section of the developer documentation. A new link file was created in the `links` directory and the endpoint was updated to the new `Getting started with Themes` destination. 

## Linked issue

Closes #551 