### PR TITLE
Fix: Broken links to SparkPost articles

### DIFF
--- a/docs/configuration/smime_email_signing.rst
+++ b/docs/configuration/smime_email_signing.rst
@@ -22,7 +22,7 @@ S/MIME Email signing adds a digital signature to your Emails, which allows recip
 .. note::
     This implementation focuses on **signing** Emails only. It doesn't encrypt the Email body, which means the Email content is still readable to anyone who has access to it. Many Email clients don't support S/MIME encryption, so signing provides verification without compatibility issues.
 
-For more detailed information about S/MIME and why to use it, see :xref:`S/MIME: secure Email encryption and signature`.
+For more detailed information about S/MIME and why to use it, read this :xref:`S/MIME: secure Email encryption and signature` article by mailbox.
 
 How it works
 ************

--- a/docs/configuration/smime_email_signing.rst
+++ b/docs/configuration/smime_email_signing.rst
@@ -22,10 +22,7 @@ S/MIME Email signing adds a digital signature to your Emails, which allows recip
 .. note::
     This implementation focuses on **signing** Emails only. It doesn't encrypt the Email body, which means the Email content is still readable to anyone who has access to it. Many Email clients don't support S/MIME encryption, so signing provides verification without compatibility issues.
 
-For more detailed information about S/MIME and why to use it, see these articles from SparkPost:
-
-- :xref:`SparkPost S/MIME Overview`
-- :xref:`SparkPost S/MIME Technical Guide`
+For more detailed information about S/MIME and why to use it, see :xref:`S/MIME: secure Email encryption and signature`.
 
 How it works
 ************
@@ -107,7 +104,7 @@ For production use, obtain S/MIME certificates from a trusted Certificate Author
 2. Submitting the CSR to the CA along with identity verification documents
 3. Receiving the signed certificate from the CA
 
-For detailed instructions on obtaining production certificates, see the :xref:`SparkPost S/MIME Technical Guide`.
+To see an example of how this process works in practice, refer to the :xref:`Mozilla guide on obtaining S/MIME certificates` article by Mozilla.
 
 Installing certificates
 ***********************
@@ -286,13 +283,17 @@ Additional resources
 
 For more information about S/MIME:
 
-- :xref:`SparkPost S/MIME Overview`
-- :xref:`SparkPost S/MIME Technical Guide`
+- :xref:`S/MIME: secure Email encryption and signature`
+- :xref:`Mozilla guide on obtaining S/MIME certificates`
 - :xref:`OpenSSL Documentation`
 
 Related documentation
 *********************
 
+.. vale off
+
 - :doc:`/configuration/settings` - General Email settings configuration
-- :doc:`/Channels/Emails` - Emails overview and management
+- :doc:`/channels/emails` - Emails overview and management
 - :doc:`/configuration/cron_jobs` - Setting up Cron jobs for Email sending
+
+.. vale on

--- a/docs/links/mailbox_smime_overview.py
+++ b/docs/links/mailbox_smime_overview.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "S/MIME: secure Email encryption and signature" 
+link_text = "S/MIME: Secure e-mail encryption and signature" 
+link_url = "https://mailbox.org/en/blog/smime-secure-e-mail-encryption-and-signature/" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/mozilla_obtaining_smime_certificate.py
+++ b/docs/links/mozilla_obtaining_smime_certificate.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Mozilla guide on obtaining S/MIME certificates" 
+link_text = "Instructions for obtaining a personal S/MIME certificate by creating a CSR" 
+link_url = "https://support.mozilla.org/en-US/kb/instructions-smime-certificate-using-csr" 
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/sparkpost_smime_overview.py
+++ b/docs/links/sparkpost_smime_overview.py
@@ -1,7 +1,0 @@
-from . import link
-
-link_name = "SparkPost S/MIME Overview" 
-link_text = "What is S/MIME and Why Should You Use It?" 
-link_url = "https://www.sparkpost.com/blog/s-mime-sparkpost/" 
-
-link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/links/sparkpost_smime_technical.py
+++ b/docs/links/sparkpost_smime_technical.py
@@ -1,7 +1,0 @@
-from . import link
-
-link_name = "SparkPost S/MIME Technical Guide" 
-link_text = "S/MIME, Part 2: Signed, Sealed, and Delivered with SparkPost" 
-link_url = "https://www.sparkpost.com/blog/s-mime-part-2-signed-sealed-delivered-sparkpost/" 
-
-link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
## Description

This PR fixes broken links to SparkPost by replacing them with comparable sources as below:

| Original SparkPost Link | New Destination Link |
| :--- | :--- |
| https://www.sparkpost.com/blog/s-mime-sparkpost/ | https://mailbox.org/en/blog/smime-secure-e-mail-encryption-and-signature/ |
| https://www.sparkpost.com/blog/s-mime-part-2-signed-sealed-delivered-sparkpost/ | https://support.mozilla.org/en-US/kb/instructions-smime-certificate-using-csr |

## Linked Issue

Closes #664