### PR TITLE
docs: Document global defaults for Preference Center and UTM tracking

### DIFF
--- a/docs/channels/utm_tags.rst
+++ b/docs/channels/utm_tags.rst
@@ -71,12 +71,13 @@ Mautic supports UTM tagging in Emails. Mautic can automatically append UTM tags 
 Setting global UTM defaults
 ===========================
 
-Configure default UTM values in Configuration > Email Settings. When you create a new Email, Mautic pre-populates the UTM fields with these defaults. This saves time if most of your Emails use similar tracking values.
+Configure default UTM values in **Configuration > Email Settings**. When you create a new Email, Mautic pre-populates the UTM fields with these defaults. This saves time if most of your Emails use similar tracking values.
 
 .. note::
-    Default UTM tags only apply to new Emails. If you edit an existing Email or clone an Email, the original values remain unchanged.
 
-For more details on configuring defaults, see :ref:`Default UTM tags<configuration/settings:Default UTM tags>`.
+   Default UTM tags only apply to new Emails. If you edit an existing Email or clone an Email, the original values remain unchanged.
+
+For more details on configuring defaults, see :ref:`Default UTM tags <configuration/settings:Default UTM tags>`.
 
 Setting UTM tags on individual Emails
 =====================================

--- a/docs/channels/utm_tags.rst
+++ b/docs/channels/utm_tags.rst
@@ -68,6 +68,19 @@ Using UTM tags in Emails
 
 Mautic supports UTM tagging in Emails. Mautic can automatically append UTM tags to all links in an Email by entering the appropriate Campaign values in the fields provided.
 
+Setting global UTM defaults
+===========================
+
+Configure default UTM values in Configuration > Email Settings. When you create a new Email, Mautic pre-populates the UTM fields with these defaults. This saves time if most of your Emails use similar tracking values.
+
+.. note::
+    Default UTM tags only apply to new Emails. If you edit an existing Email or clone an Email, the original values remain unchanged.
+
+For more details on configuring defaults, see :ref:`Default UTM tags<configuration/settings:Default UTM tags>`.
+
+Setting UTM tags on individual Emails
+=====================================
+
 #. In Mautic, click Channels > Emails.
 #. Create a new Email or edit an existing Email. If you choose to edit an existing Email, click the Email and then click Edit.
 #. Locate the Google Analytics UTM tags section on the bottom right.

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -398,13 +398,31 @@ Message settings
 * **Convert embed images to Base64** - Select **Yes** to display embedded images in Emails using embedded base64 code rather than as embedded images.
 
 * **Disable trackable URLs** - Removes tracking from URLs in your Emails. Select Yes to prevent tracking, reporting on, and using decisions based on link clicks. Some Email service providers don't like redirecting URLs. Using trackable URLs in your Emails may impact deliverability.
-  
+
+Default UTM tags
+----------------
+
+Configure default UTM tags for new Emails. When you create a new Email, Mautic pre-populates the UTM fields with these defaults. Existing Emails, edited Emails, and cloned Emails retain their own UTM values.
+
+* **Default UTM source** - The default value for the Campaign Source field. For example: ``newsletter``, ``website``.
+
+* **Default UTM medium** - The default value for the Campaign Medium field. For example: ``email``, ``cpc``.
+
+* **Default UTM campaign** - The default value for the Campaign Name field. For example: ``spring_sale``, ``product_launch``.
+
+* **Default UTM content** - The default value for the Campaign Content field. For example: ``header_link``, ``footer_link``.
+
+.. note::
+    Default UTM tags only apply to new Emails. If you edit an existing Email or clone an Email, the original values remain unchanged - even if those values are empty.
+
 Unsubscribe settings
 ====================
 
 .. image:: images/unsubscribe-settings.png
   :width: 600
   :alt: Screenshot showing Unsubscribe Settings Configuration in Mautic
+
+* **Default Preference Center** - Select a default Preference Center page for new Emails. When you create a new Email, Mautic pre-populates the Preference Center field with this selection. Existing Emails, edited Emails, and cloned Emails retain their own Preference Center selection. For more information on creating Preference Center pages, see the :doc:`Preference Center documentation</contacts/preference_center>`.
 
 * **Text for the {unsubscribe_text} token** -  Like the ``{webview_text}`` token,  this allows you to customize the **Unsubscribe** link. 
 

--- a/docs/contacts/preference_center.rst
+++ b/docs/contacts/preference_center.rst
@@ -179,6 +179,9 @@ When creating or editing an Email, you can select the Preference Center Page fro
 
 |
 
+.. tip::
+    You can set a default Preference Center in Configuration > Email Settings. When you create a new Email, Mautic pre-populates the Preference Center field with this default selection. This saves time if most of your Emails use the same Preference Center page. For details, see :ref:`Unsubscribe settings<configuration/settings:Unsubscribe settings>`.
+
 Keep in mind that your mail must use the same language as the Preference Center landing page - if not, Mautic shows the default Preference Center.
 
 Now when sending the Email, all recipients can click the Unsubscribe link provided in the ``{unsubscribe_text}`` and ``{unsubscribe_url}`` variables, taking them to the new Preference Center.

--- a/docs/contacts/preference_center.rst
+++ b/docs/contacts/preference_center.rst
@@ -180,7 +180,8 @@ When creating or editing an Email, you can select the Preference Center Page fro
 |
 
 .. tip::
-    You can set a default Preference Center in Configuration > Email Settings. When you create a new Email, Mautic pre-populates the Preference Center field with this default selection. This saves time if most of your Emails use the same Preference Center page. For details, see :ref:`Unsubscribe settings<configuration/settings:Unsubscribe settings>`.
+
+   You can set a default Preference Center in **Configuration > Email Settings**. When you create a new Email, Mautic pre-populates the Preference Center field with this default selection. This saves time if most of your Emails use the same Preference Center page. For details, see :ref:`Unsubscribe settings <configuration/settings:Unsubscribe settings>`.
 
 Keep in mind that your mail must use the same language as the Preference Center landing page - if not, Mautic shows the default Preference Center.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/4b00c4f8-6966-4c01-a411-fdacb2b7e9ad)

Documents the new Email configuration settings introduced in [PR #15905](https://github.com/mautic/mautic/pull/15905) that allow admins to configure site-wide defaults for Preference Center and UTM tracking parameters.

## Changes

### configuration/settings.rst
- New "Default UTM tags" subsection in Message settings documenting the four default UTM fields (source, medium, campaign, content)
- New "Default Preference Center" setting in Unsubscribe settings section
- Notes explaining that defaults only apply to new Emails; existing, edited, and cloned Emails retain their own values

### channels/utm_tags.rst
- New "Setting global UTM defaults" section explaining how to configure default UTM values in Configuration > Email Settings
- Cross-reference to the detailed settings documentation

### contacts/preference_center.rst
- Added tip about configuring a default Preference Center in Email settings
- Cross-reference to the Unsubscribe settings documentation

---

_Tip: Create additional [Docs Collections](https://app.gopromptless.ai/doc-collections) to keep multiple repositories in sync 📚_