### PR TITLE
docs: Clarify relative date filter behavior across languages

### DIFF
--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -105,7 +105,6 @@ POST
 post
 PUT
 Rackspace
-rebase
 Remarketing
 REST
 Salesforce

--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -105,6 +105,7 @@ POST
 post
 PUT
 Rackspace
+rebase
 Remarketing
 REST
 Salesforce

--- a/docs/segments/manage_segments.rst
+++ b/docs/segments/manage_segments.rst
@@ -450,7 +450,7 @@ Example - Consider that today is ``2022-03-05``:
 * ``Date identified greater or equal -1`` year returns all Contacts identified 2021-03-05 and after.
 * ``Date identified greater than -1`` year returns all Contacts identified after 2021-03-05.
 
-Beside this you can specify your date with text. These formulas are **translatable**, so make sure you use them in correct format.
+Beside this you can specify your date with text. These formulas are **translatable** - Mautic displays them in your current language setting.
 
 * ``birthday`` / ``anniversary``
 * ``birthday -7 days`` / ``anniversary -7 days``
@@ -460,6 +460,10 @@ Beside this you can specify your date with text. These formulas are **translatab
 * ``this year`` / ``last year`` / ``next year``
 * ``first day of previous month`` / ``first day of January 2022``
 * ``last day of previous month`` / ``last day of January 2022``
+
+.. tip::
+
+   Relative date values like ``today``, ``tomorrow``, and ``this week`` work correctly regardless of your Mautic language setting. Switching languages doesn't affect how Segments evaluate these filters.
 
 Example (Consider that today is ``2022-03-05``):
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/24ae3502-a0ec-4941-901d-e88471ea9092)

Clarifies that relative date values in Segment filters work correctly regardless of Mautic's language setting, based on the bug fix in [PR #15791](https://github.com/mautic/mautic/pull/15791).

## Changes

### segments/manage_segments.rst
- **Updated Date options section**: Simplified the explanation of translatable date formulas to clarify that Mautic displays them in the current language setting
- **New tip**: Added a tip explaining that relative date values like `today`, `tomorrow`, and `this week` work correctly regardless of language setting, and switching languages doesn't affect Segment evaluation

## Context

PR #15791 fixed a bug where relative date values in Segment filters would break when users switched languages. Previously, values like 'today' stored in German ('heute') would become '1970-01-01 00:00' when switching to English. The fix ensures relative dates are stored consistently and translated at the UI level, making Segment evaluation language-independent.

---

_Tip: Use labels in the [Promptless dashboard](https://app.gopromptless.ai) to categorize suggestions by release or team 🏷️_