### PR TITLE
Update mj-attributes documentation for MJML theme support

### DIFF
--- a/docs/builders/creating_themes.rst
+++ b/docs/builders/creating_themes.rst
@@ -80,9 +80,11 @@ Head Components
 
 .. vale on
 
-Mautic processes most of the ``<mj-head>`` components. ``<mj-attributes>`` don't run.
+Mautic processes the ``<mj-head>`` components, including ``<mj-attributes>``.
 
-**Tested elements** include: ``mj-breakpoint``, ``mj-font``, ``mj-html-attributes``, ``mj-style``, ``mj-title``, and ``mj-preview``.
+With ``<mj-attributes>``, you can define default styling for Builder blocks. When you drag blocks into the Email editor, they inherit the Theme's colors, fonts, and spacing rather than generic defaults. The Brienz Theme demonstrates this approach.
+
+**Tested elements** include: ``mj-attributes``, ``mj-breakpoint``, ``mj-font``, ``mj-html-attributes``, ``mj-style``, ``mj-title``, and ``mj-preview``.
 
 .. vale off
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/cfbb6b45-0d70-43c9-be2c-35c3a181fc83)

Corrects the outdated statement that mj-attributes don't run. Documents that mj-attributes are now supported and enable theme creators to define default styling for builder blocks.

**Trigger Events**
- [mautic/mautic PR #16042: \[MJML\] Apply theme style to GrapesJS builder blocks](https://github.com/mautic/mautic/pull/16042)

---

_Tip: Configure how Promptless handles changelogs in [Agent Settings](https://app.gopromptless.ai/configure/settings) 📋_