### PR TITLE
Clarify {signature} token behavior with owner-as-mailer

### DIFF
--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -296,9 +296,9 @@ Setting a signature happens in two places:
 
    .. important::
 
-     For the ``{signature}`` token to use the owner's signature, the Email must have **Use owner as mailer** enabled in its advanced settings. Enabling the global **Mailer is owner** setting in Configuration alone isn't sufficient.
+     For the ``{signature}`` token to use the owner's signature, you must enable **Use owner as mailer** in the Email's advanced settings. Enabling only the global **Mailer is owner** setting in Configuration isn't sufficient.
 
-     If the owner doesn't have a signature configured, the ``{signature}`` token resolves to empty when owner-as-mailer is enabled.
+     If the owner hasn't configured a signature, the ``{signature}`` token resolves to empty when you enable owner-as-mailer.
 
 
    .. vale off

--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -301,13 +301,15 @@ Setting a signature happens in two places:
      If the owner hasn't configured a signature, the ``{signature}`` token resolves to empty when you enable owner-as-mailer.
 
 
-   .. vale off
+   .. note::
 
-   When a User sends an Email directly from a Contact's profile, Mautic uses the logged-in User's signature with the 'From' name and email address specified in the **Send email** form, not the Contact owner's signature. Mautic pre-fills these values with those of the logged-in User.
+      .. vale off
 
-   .. vale on
+      When a User sends an Email directly from a Contact's profile, Mautic uses the logged-in User's signature with the 'From' name and email address specified in the **Send email** form, not the Contact owner's signature. Mautic pre-fills these values with those of the logged-in User.
 
-   This applies regardless of whether the Contact has a different owner assigned, or no owner at all. The same behavior applies when sending test Emails.
+      .. vale on
+
+      This applies regardless of whether the Contact has a different owner assigned, or no owner at all. The same behavior applies when sending test Emails.
 
 
 .. vale off

--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -282,27 +282,32 @@ Signatures
 
 Setting a signature happens in two places:
 
-#. The default signature is in the Configuration > Email Settings tab. The default text is 
+#. The default signature is in the **Configuration** > **Email Settings** tab. The default text is:
 
-.. code-block:: html
+   .. code-block:: html
 
-  Best regards,<br/>|FROM_NAME|.
+      Best regards,<br/>|FROM_NAME|.
 
-Mautic replaces the ``|FROM_NAME|`` token with the name defined in the Email Settings tab.
+   Mautic replaces the ``|FROM_NAME|`` token with the name defined in the Email Settings tab.
 
-Mautic uses this signature when the Email doesn't have **Use owner as mailer** enabled.
+   Mautic uses this signature when the Email doesn't have **Use owner as mailer** enabled.
 
 #. Each Mautic User can configure their own signature in their account settings. Mautic uses this signature when the Email has **Use owner as mailer** enabled and the Contact has an owner assigned.
 
-.. important::
-  For the ``{signature}`` token to use the owner's signature, the Email must have **Use owner as mailer** enabled in its advanced settings. Enabling the global **Mailer is owner** setting in Configuration alone isn't sufficient.
+   .. important::
 
-  If the owner doesn't have a signature configured, the ``{signature}`` token resolves to empty when owner-as-mailer is enabled.
+     For the ``{signature}`` token to use the owner's signature, the Email must have **Use owner as mailer** enabled in its advanced settings. Enabling the global **Mailer is owner** setting in Configuration alone isn't sufficient.
 
-.. note::
-  When a User sends an Email directly from a Contact's profile, Mautic uses the logged-in User's signature with the from name and Email address specified in the Email send Form - not the Contact owner's signature. Mautic pre-fills these values with those of the logged-in User.
+     If the owner doesn't have a signature configured, the ``{signature}`` token resolves to empty when owner-as-mailer is enabled.
 
-  This applies regardless of whether the Contact has a different owner assigned, or no owner at all. The same behavior applies when sending test Emails.
+
+   .. vale off
+
+   When a User sends an Email directly from a Contact's profile, Mautic uses the logged-in User's signature with the 'From' name and email address specified in the **Send email** form, not the Contact owner's signature. Mautic pre-fills these values with those of the logged-in User.
+
+   .. vale on
+
+   This applies regardless of whether the Contact has a different owner assigned, or no owner at all. The same behavior applies when sending test Emails.
 
 
 .. vale off

--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -288,18 +288,21 @@ Setting a signature happens in two places:
 
   Best regards,<br/>|FROM_NAME|.
 
-Mautic replaces the ``|FROM_NAME|`` token with the name which is also defined in the Email Settings tab.
+Mautic replaces the ``|FROM_NAME|`` token with the name defined in the Email Settings tab.
 
-Mautic uses this signature by default if the Contact doesn't have an owner assigned.
+Mautic uses this signature when the Email doesn't have **Use owner as mailer** enabled.
 
-#. Every Mautic User can configure their own signature in their account settings. Mautic uses this signature by default if the Contact has an owner assigned to them.
+#. Each Mautic User can configure their own signature in their account settings. Mautic uses this signature when the Email has **Use owner as mailer** enabled and the Contact has an owner assigned.
+
+.. important::
+  For the ``{signature}`` token to use the owner's signature, the Email must have **Use owner as mailer** enabled in its advanced settings. Enabling the global **Mailer is owner** setting in Configuration alone isn't sufficient.
+
+  If the owner doesn't have a signature configured, the ``{signature}`` token resolves to empty when owner-as-mailer is enabled.
 
 .. note::
-  There are some exceptions where the Contact owner's signature isn't used, which is when a User sends an Email directly from a Contact's profile. In this case, Mautic uses the currently logged in User's signature, with the from name and Email specified in the Email send Form, and not the Contact owner. The values used are pre-filled with those of the currently logged in Mautic User.
-  
-  It doesn't matter if the Contact has another owner assigned or if it doesn't have an owner at all.
+  When a User sends an Email directly from a Contact's profile, Mautic uses the logged-in User's signature with the from name and Email address specified in the Email send Form - not the Contact owner's signature. Mautic pre-fills these values with those of the logged-in User.
 
-  Also, when sending a test Email this is also the case.
+  This applies regardless of whether the Contact has a different owner assigned, or no owner at all. The same behavior applies when sending test Emails.
 
 
 .. vale off

--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -301,16 +301,15 @@ Setting a signature happens in two places:
      If the owner hasn't configured a signature, the ``{signature}`` token resolves to empty when you enable owner-as-mailer.
 
 
-   .. note::
+.. note::
 
-      .. vale off
+   .. vale off
 
-      When a User sends an Email directly from a Contact's profile, Mautic uses the logged-in User's signature with the 'From' name and email address specified in the **Send email** form, not the Contact owner's signature. Mautic pre-fills these values with those of the logged-in User.
+   When a User sends an Email directly from a Contact's profile, Mautic uses the logged-in User's signature with the 'From' name and email address specified in the **Send email** form, not the Contact owner's signature. Mautic pre-fills these values with those of the logged-in User.
 
-      .. vale on
+   .. vale on
 
-      This applies regardless of whether the Contact has a different owner assigned, or no owner at all. The same behavior applies when sending test Emails.
-
+   This applies regardless of whether the Contact has a different owner assigned, or no owner at all. The same behavior applies when sending test Emails.
 
 .. vale off
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/d6c98810-a914-4db6-a3cc-5092d619bd94)

Updates the Signatures documentation to accurately describe when the owner's signature is used. Clarifies that the Email must have "Use owner as mailer" enabled for the owner's signature to apply, and that the global setting alone is not sufficient.

**Trigger Events**
- [mautic/mautic PR #15931: Maut 12133 - Email Signature is missing if added by {signature} token…](https://github.com/mautic/mautic/pull/15931)

---

_Tip: See how your feedback shapes Promptless in [Agent Knowledge Base](https://app.gopromptless.ai/configure/settings) 🧠_