### PR TITLE
Document --cleanup-only flag for report scheduler command

### DIFF
--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -296,10 +296,6 @@ Command parameters:
 
 - ``--cleanup-only`` runs only the cleanup operation, removing old exported Report files without sending scheduled Reports. Use this to separate the cleanup and sending tasks to prevent duplicate Report Emails.
 
-.. note::
-
-    For releases prior to 1.1.3, it's required to append ``--env=prod`` to the cron job command to ensure commands execute correctly.
-
 Preventing duplicate Report Emails
 **********************************
 

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -274,7 +274,7 @@ Command parameters:
 
 - ``--min-contact-id`` and ``--max-contact-id`` allows the separation of Email sending by smaller chunks, by specifying contact ID ranges. If those ranges won't overlap, this allows you to run several broadcast commands in parallel.
 
-.. _send scheduled reports cron job:
+.. _send scheduled Reports Cron job:
 
 .. vale off
 
@@ -289,25 +289,29 @@ Starting with Mautic 2.12.0, it's now possible to use cron to send scheduled Rep
 
     php /path/to/mautic/bin/console mautic:reports:scheduler [--report=ID] [--cleanup-only]
 
-Command parameters:
-*******************
+Command parameters
+------------------
 
 - ``--report=ID`` specifies a Report by ID. If not provided, processes all scheduled Reports.
 
 - ``--cleanup-only`` runs only the cleanup operation, removing old exported Report files without sending scheduled Reports. Use this to separate the cleanup and sending tasks to prevent duplicate Report Emails.
 
+.. vale off
+
 Preventing duplicate Report Emails
 **********************************
 
-Running the Report send and cleanup operations at the same time can cause duplicate Report Emails. To prevent this, run separate cron jobs:
+.. vale on
 
-1. A cleanup-only job that removes old exported files:
+Running the Report send and cleanup operations at the same time can cause duplicate Report Emails. To prevent this, run separate Cron jobs:
+
+#. A cleanup-only job that removes old exported files:
 
    .. code-block:: php
 
        php /path/to/mautic/bin/console mautic:reports:scheduler --cleanup-only
 
-2. A separate job that sends scheduled Reports:
+#. A separate job that sends scheduled Reports:
 
    .. code-block:: php
 

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -305,7 +305,7 @@ Preventing duplicate Report Emails
 
 Running the Report send and cleanup operations at the same time can cause duplicate Report Emails. To prevent this, run separate Cron jobs:
 
-#. A cleanup-only job that removes old exported files:
+#. A cleanup-only job that removes old exported files without sending Report Emails:
 
    .. code-block:: php
 

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -274,6 +274,8 @@ Command parameters:
 
 - ``--min-contact-id`` and ``--max-contact-id`` allows the separation of Email sending by smaller chunks, by specifying contact ID ranges. If those ranges won't overlap, this allows you to run several broadcast commands in parallel.
 
+.. _send scheduled reports cron job:
+
 .. vale off
 
 Send scheduled Reports cron job
@@ -285,11 +287,37 @@ Starting with Mautic 2.12.0, it's now possible to use cron to send scheduled Rep
 
 .. code-block:: php
 
-    php /path/to/mautic/bin/console mautic:reports:scheduler [--report=ID]
+    php /path/to/mautic/bin/console mautic:reports:scheduler [--report=ID] [--cleanup-only]
 
-.. note:: 
+Command parameters:
+*******************
 
-    for releases prior to 1.1.3, it's required to append ``--env=prod`` to the cron job command to ensure commands execute correctly.
+- ``--report=ID`` specifies a Report by ID. If not provided, processes all scheduled Reports.
+
+- ``--cleanup-only`` runs only the cleanup operation, removing old exported Report files without sending scheduled Reports. Use this to separate the cleanup and sending tasks to prevent duplicate Report Emails.
+
+.. note::
+
+    For releases prior to 1.1.3, it's required to append ``--env=prod`` to the cron job command to ensure commands execute correctly.
+
+Preventing duplicate Report Emails
+**********************************
+
+Running the Report send and cleanup operations at the same time can cause duplicate Report Emails. To prevent this, run separate cron jobs:
+
+1. A cleanup-only job that removes old exported files:
+
+   .. code-block:: php
+
+       php /path/to/mautic/bin/console mautic:reports:scheduler --cleanup-only
+
+2. A separate job that sends scheduled Reports:
+
+   .. code-block:: php
+
+       php /path/to/mautic/bin/console mautic:reports:scheduler
+
+Stagger these jobs so they don't run at the same time.
 
 .. vale off
 

--- a/docs/reports/reports.rst
+++ b/docs/reports/reports.rst
@@ -177,9 +177,13 @@ Cron job to schedule Reports
 
 Mautic requires the following cron command to be able to send scheduled Reports:
 
-``php /path/to/mautic/bin/console mautic:reports:scheduler [--report=ID]``
+``php /path/to/mautic/bin/console mautic:reports:scheduler [--report=ID] [--cleanup-only]``
 
-The ``--report=ID`` argument allows you to specify a Report by ID if required. For more information, see :ref:`Cron jobs<send scheduled reports cron job>`.
+- The ``--report=ID`` argument allows you to specify a Report by ID if required.
+
+- The ``--cleanup-only`` argument runs only the cleanup operation to remove old exported files without sending Reports.
+
+For more information, see :ref:`Send scheduled Reports cron job<send scheduled reports cron job>`.
 
 Report options
 ==============

--- a/docs/reports/reports.rst
+++ b/docs/reports/reports.rst
@@ -177,13 +177,15 @@ Cron job to schedule Reports
 
 Mautic requires the following cron command to be able to send scheduled Reports:
 
-``php /path/to/mautic/bin/console mautic:reports:scheduler [--report=ID] [--cleanup-only]``
+.. code-block:: php
 
-- The ``--report=ID`` argument allows you to specify a Report by ID if required.
+   php /path/to/mautic/bin/console mautic:reports:scheduler [--report=ID] [--cleanup-only]
 
-- The ``--cleanup-only`` argument runs only the cleanup operation to remove old exported files without sending Reports.
+* The ``--report=ID`` argument allows you to specify a Report by ID if required.
 
-For more information, see :ref:`Send scheduled Reports cron job<send scheduled reports cron job>`.
+* The ``--cleanup-only`` argument runs only the cleanup operation to remove old exported files without sending Reports.
+
+For more information, see :ref:`Send scheduled Reports Cron job<send scheduled Reports Cron job>`.
 
 Report options
 ==============


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/18a18613-b2ff-489b-97de-e27d0be29fd6)

Adds documentation for the new --cleanup-only flag on mautic:reports:scheduler that allows users to run report cleanup separately from report sending, preventing duplicate Report Emails.

**Trigger Events**
- [mautic/mautic PR #16077: Prevent duplicate report cleanup jobs](https://github.com/mautic/mautic/pull/16077)

---

_Tip: Use Vale? Add your vale.ini when setting up your [Docs Collection](https://app.gopromptless.ai/doc-collections)._