### PR TITLE
Document contact timeline date grouping

### DIFF
--- a/docs/contacts/manage_contacts.rst
+++ b/docs/contacts/manage_contacts.rst
@@ -195,7 +195,9 @@ Image
 History
 =======
 
-Event history tracks any engagements between Mautic and a Contact. To find certain event types, search in the **Include events by source** text box. To exclude event types from the history while you're looking at it, use **Exclude events by source**.
+Event history tracks any engagements between Mautic and a Contact. Mautic groups events by day so you can scan activity quickly. Group headers display "Today", "Yesterday", or a formatted date, while individual events show only the time.
+
+To find specific event types, search in the **Include events by source** text box. To exclude event types from the history, use **Exclude events by source**.
 
 **Accessed from IP** - IP addresses which the Contact has opened or clicked Emails, visited your tracked pages, etc. from.
 

--- a/docs/contacts/manage_contacts.rst
+++ b/docs/contacts/manage_contacts.rst
@@ -195,7 +195,7 @@ Image
 History
 =======
 
-Event history tracks any engagements between Mautic and a Contact. Mautic groups events by day so you can scan activity quickly. Group headers display "Today", "Yesterday", or a formatted date, while individual events show only the time.
+Event history tracks any engagements between Mautic and a Contact. Mautic groups events by day so you can scan activity quickly. Group headers display 'Today', 'Yesterday', or a formatted date, while individual events show only the time.
 
 To find specific event types, search in the **Include events by source** text box. To exclude event types from the history, use **Exclude events by source**.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/65c5a796-bfe9-4f37-a7f6-b2bcee717317)

Documents the new timeline organization that groups events by day with "Today", "Yesterday", or formatted date headers, making it easier to scan Contact activity.

**Trigger Events**
- [mautic/mautic PR #15329: Improve contact timeline readability with intuitive date grouping](https://github.com/mautic/mautic/pull/15329)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_