### PR TITLE
Document Form results cleanup CLI commands

### DIFF
--- a/docs/configuration/command_line_interface.rst
+++ b/docs/configuration/command_line_interface.rst
@@ -121,6 +121,12 @@ These are the commands you may need to use in relation to your Mautic instance. 
      - 
    * - ``mautic:fields:analse``
      - Analyze Custom Fields table and return table or file with results. See :doc:`/contacts/custom_fields`.
+     -
+   * - ``mautic:forms:delete-orphan-form-submission-records-from-form-results-table``
+     - Deletes orphan records from Form results tables where the associated submission record no longer exists. Run this after directly deleting submission records from the database.
+     -
+   * - ``mautic:forms:delete-results-table``
+     - Deletes orphan Form results tables where the associated Form has been deleted. Run this after directly deleting Forms from the database.
      - 
    * - ``mautic:import``
      - If the CSV import is configured to run in background then this command will pick up the pending import jobs and imports the data from CSV files to Mautic.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/261bedb7-2699-4241-b444-bfe7fd7c1f9b)

Adds documentation for two new CLI maintenance commands introduced in PR #16123: mautic:forms:delete-results-table and mautic:forms:delete-orphan-form-submission-records-from-form-results-table. These commands help administrators clean up orphan Form results data after direct database modifications.

**Trigger Events**
- [mautic/mautic PR #16123: Deleting Specific results for forms were not getting deleted from form_results_XXX table](https://github.com/mautic/mautic/pull/16123)

---

_Tip: Request one-off documentation tasks in the Dashboard under [New Task](https://app.gopromptless.ai/new-task) 🚀_