### PR TITLE
Update clone event docs for tile-based UI

### DIFF
--- a/docs/campaigns/campaign_builder.rst
+++ b/docs/campaigns/campaign_builder.rst
@@ -363,16 +363,16 @@ To clone an event:
 
    |
 
-#. Click on the anchor of the event after which you want to insert the cloned event. This opens up a modal window.
+#. Click on the anchor of the event after which you want to insert the cloned event. This opens a panel with event type options and a tile showing the cloned event details.
 
-#. In the modal window, click the "Insert" button to paste the stored event.
+#. Click the cloned event tile to paste the stored event into the Campaign.
 
    |
 
    .. image:: images/paste_cloned_event_modal.png
       :width: 600
       :align: center
-      :alt: Screenshot of the modal window with the insert option to paste the cloned event
+      :alt: Screenshot of the Campaign builder panel with the cloned event tile
 
    |
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/7d208af0-edd5-42b4-be33-be9e81693332)

Updates the Campaign builder cloning documentation to reflect PR #16158 which changes the cloned event insert option from a button-based panel to a clickable tile component.

**Trigger Events**
- [mautic/mautic PR #16158: \[UXUI-247\] Fix cloned campaign event insert option](https://github.com/mautic/mautic/pull/16158)

---

_Tip: Worried about broken links? Ask Promptless to find and fix them automatically 🔗_