### PR TITLE
Clarify email domain submission filter formats and auto-enable behavior

### DIFF
--- a/docs/components/forms.rst
+++ b/docs/components/forms.rst
@@ -587,13 +587,22 @@ To configure globally blocked domains - applying to all Forms in your Mautic ins
   :width: 600
   :alt: Screenshot showing global domain blocking
 
-Specify domains, one per line, using either full Email addresses or entire domains using an asterisk before the domain name, which acts as a wildcard. Ensure you save your changes.
+Specify domains, one per line. You can enter:
+
+- A plain domain name such as ``blocked.com`` to block all Email addresses from that domain
+- A full Email address such as ``spam@example.com`` to block a specific address
+- A wildcard pattern such as ``*@blocked.com`` to match patterns
+
+Ensure you save your changes.
 
 
 Applying domain name filtering to a Form
 ========================================
 
-To apply domain name filtering on a Mautic Form, add an Email field to the Form - after setting up the domain exclusions in the previous step - and under the Validation tab, set the Domain name submission filter switch to Yes.
+To apply domain name filtering on a Mautic Form, add an Email field to the Form. Under the Validation tab, set the Domain name submission filter switch to Yes.
+
+.. note::
+  When you have blocked domains configured in **Configuration > Form Settings**, new Email fields automatically enable the Domain name submission filter. You can turn this off for individual fields if needed.
 
 .. image:: images/forms/block_domains_form.png
   :width: 600

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -455,7 +455,7 @@ Form settings
   :width: 600
   :alt: Screenshot showing Form Settings Configuration in Mautic
 
-* **Do not accept submission from these domain names** - To block Contacts with specific Email domains from submitting your Forms, enter those domains in the dialog box. Select an option on each Form you want to apply this block to. You can restrict either specific Email aliases that belong to a domain or an entire domain. To block the entire domain, you can use wildcards (*).
+* **Do not accept submission from these domain names** - To block Contacts with specific Email domains from submitting your Forms, enter those domains in the dialog box, one per line. You can enter a plain domain name such as ``blocked.com``, a full Email address such as ``spam@example.com``, or a wildcard pattern such as ``*@blocked.com``. Enable the Domain name submission filter option on each Email field where you want to apply this block. When blocked domains are configured here, new Email fields on Forms automatically enable the filter.
 
 Contact settings
 ****************


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/4fb46dc7-7a47-4542-9aa3-cd8efcf00c6d)

Updates documentation to clarify that plain domain names (like blocked.com) work without wildcards for the domain submission filter, and documents the new auto-enable behavior where Email fields automatically turn on the domain filter when blocked domains are configured in Form Settings.

**Trigger Events**
- [mautic/mautic PR #16171: Fix email domain submission filter](https://github.com/mautic/mautic/pull/16171)

---

_Tip: Use Vale? Add your vale.ini when setting up your [Docs Collection](https://app.gopromptless.ai/doc-collections)._