### PR TITLE
Document Email and Landing Page preview PDF download feature

### DIFF
--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -116,6 +116,19 @@ An Email Draft may be previewed by appending ``/draft`` to the end of the Email 
   :width: 400
   :alt: Screenshot showing the Preview Draft URL link on the Email edit interface.
 
+.. vale off
+
+Downloading Email previews as PDF
+---------------------------------
+
+.. vale on
+
+You can download Email previews as PDF files. In the Preview URL panel on the Email details page, a download button appears next to the preview button. Clicking this button opens a PDF version of the Email preview in a new browser tab.
+
+The PDF download feature works with both standard previews and Draft previews. If an Email has a Draft version, both preview panels include download buttons.
+
+If you select a Contact in the preview settings before downloading, the PDF includes Contact-specific token values rendered in the content.
+
 
 Translations
 ============

--- a/docs/components/landing_pages.rst
+++ b/docs/components/landing_pages.rst
@@ -54,3 +54,16 @@ You can preview a Landing Page Draft may by appending ``/draft`` to the end of t
   :width: 400
   :alt: Screenshot showing the Preview Draft URL link on the Landing Page edit interface.
 
+.. vale off
+
+Downloading Landing Page previews as PDF
+========================================
+
+.. vale on
+
+You can download Landing Page previews as PDF files. In the Preview URL panel on the Landing Page details overview, a download button appears next to the preview button. Clicking this button opens a PDF version of the Landing Page preview in a new browser tab.
+
+The PDF download feature works with both standard previews and Draft previews. If a Landing Page has a Draft version, both preview panels include download buttons.
+
+If you select a Contact in the preview settings before downloading, the PDF includes Contact-specific token values rendered in the content.
+


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/3220160d-c03c-4d46-91c4-a7343ff70c8f)

Documents the new PDF download functionality added in mautic/mautic PR #16187. Users can now download Email and Landing Page previews as PDF files by clicking a download button in the Preview URL panel.

**Trigger Events**
- [mautic/mautic PR #16187: Implement email and page preview PDF downloads](https://github.com/mautic/mautic/pull/16187)

---

_Tip: Assign suggestions to team members in the [Promptless dashboard](https://app.gopromptless.ai) to claim work 👥_