### PR TITLE
Document mj-preview tag for Email preview text in MJML Themes

### DIFF
--- a/docs/builders/creating_themes.rst
+++ b/docs/builders/creating_themes.rst
@@ -84,6 +84,17 @@ Mautic processes the ``<mj-head>`` components, including ``<mj-attributes>``.
 
 With ``<mj-attributes>``, you can define default styling for Builder blocks. When you drag blocks into the Email editor, they inherit the Theme's colors, fonts, and spacing rather than generic defaults. The Brienz Theme demonstrates this approach.
 
+With ``<mj-preview>``, you can set the preview text that recipients see in their inbox before opening the Email. This text appears after the subject line in most Email clients and helps improve open rates by giving recipients a glimpse of the Email content.
+
+.. code-block:: xml
+
+    <mj-head>
+      <mj-preview>Your preview text here</mj-preview>
+      <mj-attributes>
+        <!-- your default styles -->
+      </mj-attributes>
+    </mj-head>
+
 **Tested elements** include: ``mj-attributes``, ``mj-breakpoint``, ``mj-font``, ``mj-html-attributes``, ``mj-style``, ``mj-title``, and ``mj-preview``.
 
 .. vale off


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/4a94df75-d006-4fec-ab28-36ac580b9bd7)

Adds explanation and code example for using the mj-preview tag to set Email preview text that appears in recipients' inboxes before opening an Email.

**Trigger Events**
- [mautic/mautic PR #16106: Fix TypeError when MJML theme contains `\<mj-preview\>` tag](https://github.com/mautic/mautic/pull/16106)

---

_Tip: Use Vale? Add your vale.ini when setting up your [Docs Collection](https://app.gopromptless.ai/doc-collections)._