### PR TITLE
Clarify behavioral date filters evaluate most recent date

### DIFF
--- a/docs/segments/manage_segments.rst
+++ b/docs/segments/manage_segments.rst
@@ -303,6 +303,9 @@ Configuring Segment filters
     * Set Fields to **Available for Segments = Yes** in your Custom Field manager to display here.
 
   * Contact behavior and actions
+
+    * Behavioral date filters, such as **Read any email (date)** and **Sent any email (date)**, evaluate the most recent date when a Contact has multiple occurrences. For example, if a Contact read emails on January 1 and March 15, the **Read any email (date)** filter evaluates March 15 as the Contact's read date.
+
   * Primary Company fields
 
     * Set Fields to **Available for Segments = Yes** in your Custom Field manager to appear here.

--- a/docs/segments/manage_segments.rst
+++ b/docs/segments/manage_segments.rst
@@ -304,7 +304,11 @@ Configuring Segment filters
 
   * Contact behavior and actions
 
+    .. vale off
+
     * Behavioral date filters, such as **Read any email (date)** and **Sent any email (date)**, evaluate the most recent date when a Contact has multiple occurrences. For example, if a Contact read emails on January 1 and March 15, the **Read any email (date)** filter evaluates March 15 as the Contact's read date.
+
+    .. vale on
 
   * Primary Company fields
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/9765a00c-cf64-43ae-a9e6-d524afdd654c)

Document that segment behavioral date filters like "Read any email (date)" and "Sent any email (date)" evaluate the most recent occurrence when a Contact has multiple entries. This clarification addresses a bug fix in mautic/mautic#16224 that corrected the filter behavior.

**Trigger Events**
- [mautic/mautic PR #16224: Fix segment filter mails read is not working correctly](https://github.com/mautic/mautic/pull/16224)

---

_Tip: Whenever you leave a comment tagged `@Promptless` on a Promptless PR, Promptless will remember it for future suggestions 🧠_