### PR TITLE
Document inline text editing and Typography section in GrapesJS Builder

### DIFF
--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -123,6 +123,7 @@ SMTP
 SNS
 SparkPost
 SSO
+strikethrough
 sublicense
 SugarCRM
 Suhosin

--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -17,6 +17,7 @@ boolean
 booleans
 cc
 CCPA
+CKEditor
 Citrix
 Clearbit
 CloudAMQP

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -63,21 +63,24 @@ With the Asset Manager is easier to organize your media files and it's enough to
 Editing text
 ============
 
-GrapesJS uses inline text editing. Select a text Component and start typing to make changes directly on the canvas.
+GrapesJS uses inline text editing powered by CKEditor. Double click a text Component to open the inline editor and edit directly on the canvas.
 
-The text editor includes standard formatting options:
+The inline editor includes standard formatting options:
 
 * Bold, italic, underline and strikethrough
+* Font family, font color and font background color
 * Text alignment
 * Ordered and unordered lists
+* Headings
 * Links and anchors
+* Tables
 * Tokens for personalization
 
-You can paste content from external sources like Microsoft Word or Google Docs. The editor preserves basic formatting while adapting it for Email and Landing Page layouts.
+You can paste content from external sources like Microsoft Word or Google Docs. The editor keeps basic formatting and adapts it for Email and Landing Page layouts.
 
 .. tip::
 
-   Click outside the text Component or press ``Escape`` to finish editing and return to the canvas.
+   Click outside the text Component to finish editing and return to the canvas.
 
 About the builder
 *****************
@@ -149,18 +152,25 @@ To learn more about creating Themes please :doc:`check the documentation</builde
 Typography
 **********
 
-The Style Manager includes a Typography section for styling text Components. Select any text Component on the canvas, then open the Style panel to access these controls:
+The Style Manager includes a Typography section for styling text Components. Select a text Component on the canvas, then open the Style panel to reach these controls:
 
-* **Font family** - choose from available fonts
+* **Font family** - choose from the available fonts
 * **Font size** - set the text size in pixels
-* **Font weight** - adjust text weight from light to bold
-* **Letter spacing** - control spacing between characters
+* **Font weight** - adjust the weight from light to bold
+* **Letter spacing** - control the spacing between characters
 * **Color** - set the text color
-* **Line height** - adjust vertical spacing between lines
+* **Line height** - adjust the vertical spacing between lines
 * **Text align** - align text left, center, right, or justify
-* **Text shadow** - add shadow effects to text
+* **Text decoration** - apply none, underline, or strikethrough
+* **Font style** - switch between normal and italic
 
-These settings apply to the selected Component and override Theme defaults. Use them to fine-tune headings, paragraphs, and other text elements in legacy Themes that lack modern styling flexibility.
+Mautic resolves typography across three levels, where each level overrides the one before it:
+
+#. **Theme defaults** - the base styles defined by the Theme.
+#. **Component typography** - the Style Manager settings listed in this section, which apply to the selected Component.
+#. **Inline editor** - formatting you apply to individual characters or words with the CKEditor inline toolbar when you double click a text Component.
+
+Use the Component typography controls to fine-tune headings, paragraphs, and other text elements in legacy Themes that lack modern styling flexibility.
 
 Custom fonts
 ============

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -165,7 +165,7 @@ These settings apply to the selected Component and override Theme defaults. Use 
 Custom fonts
 ============
 
-From Mautic 5.x you can extend the **Typography** > **Fonts** list to include custom fonts.
+You can extend the **Typography** > **Fonts** list to include custom fonts.
 
 .. image:: images/editorfonts.jpg
   :width: 280

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -168,7 +168,7 @@ Mautic resolves typography across three levels, where each level overrides the o
 
 #. **Theme defaults** - the base styles defined by the Theme.
 #. **Component typography** - the Style Manager settings listed in this section, which apply to the selected Component.
-#. **Inline editor** - formatting you apply to individual characters or words with the CKEditor inline toolbar when you double click a text Component.
+#. **Inline editor** - the formatting you apply to individual characters or words with the CKEditor inline toolbar when you double click a text Component.
 
 Use the Component typography controls to fine-tune headings, paragraphs, and other text elements in legacy Themes that lack modern styling flexibility.
 

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -63,7 +63,7 @@ With the Asset Manager is easier to organize your media files and it's enough to
 Editing text
 ============
 
-GrapesJS uses inline text editing. Select a text Component and start typing to make changes directly on the canvas - there's no need to open a separate dialog.
+GrapesJS uses inline text editing. Select a text Component and start typing to make changes directly on the canvas.
 
 The text editor includes standard formatting options:
 

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -147,7 +147,7 @@ Themes
 
 If you search through the list of available Themes, the new MJML Themes ``Brienz``, ``Paprika`` and ``Confirm Me`` display only with the new Builder.
 
-To learn more about creating Themes please :doc:`check the documentation</builders/creating_themes>`. 
+To learn more about creating Themes, see :doc:`/builders/creating_themes`.
 
 Typography
 **********

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -60,6 +60,25 @@ Asset manager
 
 With the Asset Manager is easier to organize your media files and it's enough to double click the image to change it.
 
+Editing text
+============
+
+GrapesJS uses inline text editing. Select a text Component and start typing to make changes directly on the canvas - there's no need to open a separate dialog.
+
+The text editor includes standard formatting options:
+
+* Bold, italic, underline and strikethrough
+* Text alignment
+* Ordered and unordered lists
+* Links and anchors
+* Tokens for personalization
+
+You can paste content from external sources like Microsoft Word or Google Docs. The editor preserves basic formatting while adapting it for Email and Landing Page layouts.
+
+.. tip::
+
+   Click outside the text Component or press ``Escape`` to finish editing and return to the canvas.
+
 About the builder
 *****************
 
@@ -127,10 +146,26 @@ If you search through the list of available Themes, the new MJML Themes ``Brienz
 
 To learn more about creating Themes please :doc:`check the documentation</builders/creating_themes>`. 
 
-Custom fonts
-************
+Typography
+**********
 
-From Mautic 5.x you can extend the Style Manager > Typography > Fonts list to include custom fonts.
+The Style Manager includes a Typography section for styling text Components. Select any text Component on the canvas, then open the Style panel to access these controls:
+
+* **Font family** - choose from available fonts
+* **Font size** - set the text size in pixels
+* **Font weight** - adjust text weight from light to bold
+* **Letter spacing** - control spacing between characters
+* **Color** - set the text color
+* **Line height** - adjust vertical spacing between lines
+* **Text align** - align text left, center, right, or justify
+* **Text shadow** - add shadow effects to text
+
+These settings apply to the selected Component and override Theme defaults. Use them to fine-tune headings, paragraphs, and other text elements in legacy Themes that lack modern styling flexibility.
+
+Custom fonts
+============
+
+From Mautic 5.x you can extend the **Typography** > **Fonts** list to include custom fonts.
 
 .. image:: images/editorfonts.jpg
   :width: 280


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/f03f76e8-deb6-4f74-8ae6-0b87d67f3607)

Documents GrapesJS Builder text editing capabilities introduced in [PR #15839](https://github.com/mautic/mautic/pull/15839) and Typography section re-enabled in [PR #16098](https://github.com/mautic/mautic/pull/16098).

## Changes

### builders/email_landing_page.rst
- **New section: Editing text** - Documents the inline text editing experience with formatting options
- **New section: Typography** - Documents the Typography panel in the Style Manager for styling text Components (font family, size, weight, color, line height, text align, text shadow)
- **Updated: Custom fonts** - Now nested under Typography section

## Context

PR #15839 introduced inline CKEditor for text editing directly on the canvas. PR #16098 re-enabled the Typography section in the Style Manager and added alignment/list tools to the inline toolbar. These features are especially useful for legacy Themes that lack modern styling flexibility.

**Trigger Events**
- [mautic/mautic PR #15839: Inline CKEditor in GrapesJS Builder](https://github.com/mautic/mautic/pull/15839)
- [mautic/mautic PR #16098: Re-enable Typography section and styling tools in GrapesJS builder](https://github.com/mautic/mautic/pull/16098)

---

_Tip: Assign suggestions to team members in the [Promptless dashboard](https://app.gopromptless.ai) to claim work 👥_