### PR TITLE
Document deleted asset display in Contact timeline

### DIFF
--- a/docs/contacts/manage_contacts.rst
+++ b/docs/contacts/manage_contacts.rst
@@ -201,7 +201,7 @@ Event history tracks any engagements between Mautic and a Contact. To find certa
 
 **Added through API** - Contact created through API.
 
-**Asset Downloaded** - Lists which Assets a Contact downloaded from your Landing Pages or website. Combining this information with other data can help with analyzing what led a Contact to download the Asset.
+**Asset Downloaded** - Lists which Assets a Contact downloaded from your Landing Pages or website. Combining this information with other data can help with analyzing what led a Contact to download the Asset. If you have deleted the Asset, the timeline displays ``Deleted asset`` without a link or preview.
 
 **Campaign Action Triggered** - Actions within Campaigns which have already happened.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/7bf0aa55-dbf1-4154-b986-9b4e1f49ef1f)

Clarifies that when an asset has been deleted but download history remains, the Contact timeline displays "Deleted asset" without a link or preview.

**Trigger Events**
- [mautic/mautic PR #16078: Fix LogicException in contact timeline when an asset has been deleted](https://github.com/mautic/mautic/pull/16078)

---

_Tip: Tag @Promptless in GitHub PR comments to guide documentation changes during code review 🐙_