### PR TITLE
Document Custom Field Groups for Contacts and Companies

### DIFF
--- a/docs/contacts/custom_fields.rst
+++ b/docs/contacts/custom_fields.rst
@@ -131,6 +131,45 @@ Mautic stores Fields and Tags differently in the database. You can create unlimi
 
 For more information on using Tags, see the :ref:`Tags in manage Contacts` section.
 
+.. _custom field groups:
+
+Custom Field Groups
+*******************
+
+Custom Field Groups let you organize Contact and Company Custom Fields into named tabs, alongside the built-in groups - Core, Social, Personal, and Professional for Contacts, and Core, Professional, and Other for Companies. Each group appears as a tab on the Contact and Company edit and detail views, so you can keep related Fields together.
+
+Only administrators can manage Custom Field Groups. To open the list, go to **Settings > Custom Field Groups**. The list shows each group's name, alias, and the number of Fields assigned to it.
+
+.. vale off
+
+Adding a Custom Field Group
+===========================
+
+.. vale on
+
+#. Go to **Settings > Custom Field Groups** and select **New**.
+#. Enter a **Name**. The name can contain only letters, numbers, and spaces.
+#. Optionally, add a **Description**.
+#. Use the **Group order** dropdown to choose the group this one should appear before. Leave it empty to place the group last. This controls the tab order on Contact and Company views.
+#. Select **Save & Close**.
+
+When you create a group, Mautic generates an **Alias** from the name - for example, 'Billing' becomes 'billing'. Your Fields reference the group by this alias, so it's read-only and never changes, even if you rename the group later.
+
+Ordering groups
+===============
+
+Custom groups always appear after the default groups on Contact and Company views. The **Group order** dropdown sets the order of your custom groups relative to each other - pick the group this one should appear before, or leave it empty to place it last.
+
+Assigning Fields to a group
+===========================
+
+You assign a Custom Field to a group from the Field, not from the group. When you add or edit a Contact or Company Custom Field on the **Custom Fields** page, choose the group from the **Group** dropdown. This dropdown lists both the default groups and any custom groups you've created.
+
+Deleting a Custom Field Group
+=============================
+
+You can delete a group only when it has no Fields assigned to it. If you try to delete a group that still has Fields, Mautic blocks the deletion and shows this message: 'Cannot delete this field group because it still has fields assigned to it. Reassign or remove the fields first.' Reassign those Fields to another group or remove them, then delete the group.
+
 Creating Custom Fields via a command
 ************************************
 

--- a/docs/contacts/custom_fields.rst
+++ b/docs/contacts/custom_fields.rst
@@ -133,8 +133,12 @@ For more information on using Tags, see the :ref:`Tags in manage Contacts` secti
 
 .. _custom field groups:
 
+.. vale off
+
 Custom Field Groups
 *******************
+
+.. vale on
 
 Custom Field Groups let you organize Contact and Company Custom Fields into named tabs, alongside the built-in groups - Core, Social, Personal, and Professional for Contacts, and Core, Professional, and Other for Companies. Each group appears as a tab on the Contact and Company edit and detail views, so you can keep related Fields together.
 
@@ -163,12 +167,20 @@ Custom groups always appear after the default groups on Contact and Company view
 Assigning Fields to a group
 ===========================
 
+.. vale off
+
 You assign a Custom Field to a group from the Field, not from the group. When you add or edit a Contact or Company Custom Field on the **Custom Fields** page, choose the group from the **Group** dropdown. This dropdown lists both the default groups and any custom groups you've created.
 
 Deleting a Custom Field Group
 =============================
 
+.. vale on
+
+.. vale off
+
 You can delete a group only when it has no Fields assigned to it. If you try to delete a group that still has Fields, Mautic blocks the deletion and shows this message: 'Cannot delete this field group because it still has fields assigned to it. Reassign or remove the fields first.' Reassign those Fields to another group or remove them, then delete the group.
+
+.. vale on
 
 Creating Custom Fields via a command
 ************************************


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/03ec4cff-6eb7-401a-9cc5-6b9752de1bea)

Adds a Custom Field Groups section to the Manage Custom Fields page, covering creating groups, the auto-generated immutable alias, group ordering, assigning Fields via the Group dropdown, and the safe-delete rule. Documents the new feature from mautic/mautic PR #16265 (base 7.x → user docs 7.2).

**Trigger Events**
- [mautic/mautic PR #16265: Add Field Groups to the core](https://github.com/mautic/mautic/pull/16265)

---

_Tip: Worried about broken links? Ask Promptless to find and fix them automatically 🔗_