### PR TITLE
docs: Document Campaign Builder infinite canvas and centered view

### DIFF
--- a/docs/campaigns/campaign_builder.rst
+++ b/docs/campaigns/campaign_builder.rst
@@ -7,6 +7,15 @@ Using the Campaign Builder
 
 The Campaign Builder provides a blank canvas on which you can build your Campaign workflow. The Campaign Builder allows the use of conditions, decisions, and actions. It enables you to create a simple workflow by dragging and dropping various decisions, actions, and conditions onto a canvas.
 
+.. _navigating-the-canvas:
+
+Navigating the canvas
+---------------------
+
+When you open the Campaign Builder, Mautic centers the view on your Campaign. The canvas uses an infinite-canvas design without traditional scrollbars, giving you more space to build complex workflows.
+
+To pan around the canvas, click and drag on an empty area. The canvas automatically expands when you move events close to its edges.
+
 To build your Campaign, perform the following steps:
 
 #. Click **Launch the Campaign Builder** on the New Campaigns wizard. The Contact Sources menu appears as shown in the following image.

--- a/docs/campaigns/campaign_builder.rst
+++ b/docs/campaigns/campaign_builder.rst
@@ -7,14 +7,12 @@ Using the Campaign Builder
 
 The Campaign Builder provides a blank canvas on which you can build your Campaign workflow. The Campaign Builder allows the use of conditions, decisions, and actions. It enables you to create a simple workflow by dragging and dropping various decisions, actions, and conditions onto a canvas.
 
-.. _navigating-the-canvas:
-
 Navigating the canvas
 ---------------------
 
-When you open the Campaign Builder, Mautic centers the view on your Campaign. The canvas uses an infinite-canvas design without traditional scrollbars, giving you more space to build complex workflows.
+When you open the Campaign Builder, Mautic centers the view on your Campaign. The canvas uses an infinite-canvas design without traditional scroll bars, giving you more space to build complex workflows.
 
-To pan around the canvas, click and drag on an empty area. The canvas automatically expands when you move events close to its edges.
+To pan around the canvas, click, and drag on an empty area. The canvas automatically expands when you move events close to its edges.
 
 To build your Campaign, perform the following steps:
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/166e4e18-53e2-4c4a-b113-1046781d746b)

Document the Campaign Builder's infinite-canvas design: the canvas opens centered on the Campaign, removes traditional scrollbars for more workspace, supports click-and-drag panning on empty areas, and auto-expands when events approach edges. Source: mautic/mautic#16127 (awaiting merge).

---

_Tip: Send Promptless a meeting transcript in Slack to generate doc updates 📝_