### PR TITLE
Document making images clickable links in the GrapesJS Builder

### DIFF
--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -156,6 +156,17 @@ You define options as elements of the ``'editor_fonts'`` array in the local conf
     ),
 
 
+Linking an image
+****************
+
+You can turn any image in a Landing Page into a clickable link straight from the Builder, without editing the code. Select the image in the canvas, open the Settings panel on the right, and use the link fields below the 'Alt' and 'Title' fields.
+
+* The ``href`` field sets the URL the image links to. When you set it, Mautic wraps the image in a link. Leave it empty and the image stays a plain image.
+* The ``target`` field controls where the link opens. Choose 'This window' to open the link in the current tab, or select a new window to open it in a new tab.
+* The ``rel`` field sets the value of the link's ``rel`` attribute, such as ``nofollow`` or ``noopener``. This field is optional.
+
+Because Mautic only wraps the image in a link when you set the ``href`` field, an image without a URL renders normally. The link settings persist when you save and reopen the Landing Page.
+
 Reporting bugs
 ***************
 

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -159,13 +159,13 @@ You define options as elements of the ``'editor_fonts'`` array in the local conf
 Linking an image
 ****************
 
-You can turn any image in a Landing Page into a clickable link straight from the Builder, without editing the code. Select the image in the canvas, open the Settings panel on the right, and use the link fields below the 'Alt' and 'Title' fields.
+You can turn any image in a Landing Page or Email into a clickable link straight from the Builder, without editing the code. Select the image in the canvas, open the Settings panel on the right, and use the link fields below the 'Alt' and 'Title' fields.
 
 * The ``href`` field sets the URL the image links to. When you set it, Mautic wraps the image in a link. Leave it empty and the image stays a plain image.
 * The ``target`` field controls where the link opens. Choose 'This window' to open the link in the current tab, or select a new window to open it in a new tab.
 * The ``rel`` field sets the value of the link's ``rel`` attribute, such as ``nofollow`` or ``noopener``. This field is optional.
 
-Because Mautic only wraps the image in a link when you set the ``href`` field, an image without a URL renders normally. The link settings persist when you save and reopen the Landing Page.
+Because Mautic only wraps the image in a link when you set the ``href`` field, an image without a URL renders normally. The link settings persist when you save and reopen the Landing Page or Email.
 
 Reporting bugs
 ***************

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -159,10 +159,10 @@ You define options as elements of the ``'editor_fonts'`` array in the local conf
 Linking an image
 ****************
 
-You can turn any image in a Landing Page or Email into a clickable link straight from the Builder, without editing the code. Select the image in the canvas, open the Settings panel on the right, and use the link fields below the 'Alt' and 'Title' fields.
+You can turn any image in a Landing Page or Email into a clickable link straight from the Builder, without editing the code. Select the image in the canvas, open the Settings panel on the right, and use the link fields below the **Alt** and **Title** fields.
 
 * The ``href`` field sets the URL the image links to. When you set it, Mautic wraps the image in a link. Leave it empty and the image stays a plain image.
-* The ``target`` field controls where the link opens. Choose 'This window' to open the link in the current tab, or select a new window to open it in a new tab.
+* The ``target`` field controls where the link opens. Choose **This window** to open the link in the current tab, or select a new window to open it in a new tab.
 * The ``rel`` field sets the value of the link's ``rel`` attribute, such as ``nofollow`` or ``noopener``. This field is optional.
 
 Because Mautic only wraps the image in a link when you set the ``href`` field, an image without a URL renders normally. The link settings persist when you save and reopen the Landing Page or Email.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/83a9bfed-305a-4d0a-94fb-4cd05941a3f9)

Adds documentation for the new image-link feature (Mautic 7.x) that lets you turn an image in the Landing Page builder into a clickable link by setting the Href, Target, and Rel fields in the image component's Settings panel.

**Trigger Events**
- [mautic/mautic PR #16267: Add image-link plugin to wrap images in anchor tags](https://github.com/mautic/mautic/pull/16267)

---

_Tip: Enable auto-create PR in your [Configuration](https://app.gopromptless.ai/configuration) to review suggestions directly in GitHub 🤖_