### PR TITLE
Clarify segment behavioral date filters evaluate most recent date (7.2)

### DIFF
--- a/docs/segments/manage_segments.rst
+++ b/docs/segments/manage_segments.rst
@@ -303,6 +303,13 @@ Configuring Segment filters
     * Set Fields to **Available for Segments = Yes** in your Custom Field manager to display here.
 
   * Contact behavior and actions
+
+    .. vale off
+
+    * Behavioral date filters, such as **Read any email (date)** and **Sent any email (date)**, evaluate the most recent date when a Contact has multiple occurrences. For example, if a Contact read emails on January 1 and March 15, the **Read any email (date)** filter evaluates March 15 as the Contact's read date.
+
+    .. vale on
+
   * Primary Company fields
 
     * Set Fields to **Available for Segments = Yes** in your Custom Field manager to appear here.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/d3848f2c-8d90-413a-877b-d1b8f28e730f)

7.2 backport of the segment read-date clarification (PR #754 / mautic#16224), brought into 7.x via merge PR #16327. Documents that behavioral date filters like "Read any email (date)" and "Sent any email (date)" evaluate the most recent occurrence when a Contact has multiple entries. Appends to the Contact behavior and actions filter list in docs/segments/manage_segments.rst, wrapped in Vale off/on directives because the labels are verbatim lowercase UI strings.

**Trigger Events**
- [mautic/mautic PR #16327: Merge 7.1 into 7.x](https://github.com/mautic/mautic/pull/16327)

---

_Tip: Use Vale? Point your collection at your vale.ini in [Configuration](https://app.gopromptless.ai/configuration)._