### PR TITLE
docs: Document inline text editing and Typography section in GrapesJS Builder (7.2)

### DIFF
--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -19,6 +19,7 @@ booleans
 cc
 CASL
 CCPA
+CKEditor
 Citrix
 Clearbit
 CloudAMQP
@@ -132,6 +133,7 @@ SNS
 SparkPost
 spacebar
 SSO
+strikethrough
 sublicense
 SugarCRM
 Suhosin

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -60,6 +60,28 @@ Asset manager
 
 With the Asset Manager is easier to organize your media files and it's enough to double click the image to change it.
 
+Editing text
+============
+
+GrapesJS uses inline text editing powered by CKEditor. Double click a text Component to open the inline editor and edit directly on the canvas.
+
+The inline editor includes standard formatting options:
+
+* Bold, italic, underline and strikethrough
+* Font family, font color and font background color
+* Text alignment
+* Ordered and unordered lists
+* Headings
+* Links and anchors
+* Tables
+* Tokens for personalization
+
+You can paste content from external sources like Microsoft Word or Google Docs. The editor keeps basic formatting and adapts it for Email and Landing Page layouts.
+
+.. tip::
+
+   Click outside the text Component to finish editing and return to the canvas.
+
 About the builder
 *****************
 
@@ -125,12 +147,35 @@ Themes
 
 If you search through the list of available Themes, the new MJML Themes ``Brienz``, ``Paprika`` and ``Confirm Me`` display only with the new Builder.
 
-To learn more about creating Themes please :doc:`check the documentation</builders/creating_themes>`. 
+To learn more about creating Themes please :doc:`check the documentation</builders/creating_themes>`.
+
+Typography
+**********
+
+The Style Manager includes a Typography section for styling text Components. Select a text Component on the canvas, then open the Style panel to reach these controls:
+
+* **Font family** - choose from the available fonts
+* **Font size** - set the text size in pixels
+* **Font weight** - adjust the weight from light to bold
+* **Letter spacing** - control the spacing between characters
+* **Color** - set the text color
+* **Line height** - adjust the vertical spacing between lines
+* **Text align** - align text left, center, right, or justify
+* **Text decoration** - apply none, underline, or strikethrough
+* **Font style** - switch between normal and italic
+
+Mautic resolves typography across three levels, where each level overrides the one before it:
+
+#. **Theme defaults** - the base styles defined by the Theme.
+#. **Component typography** - the Style Manager settings listed in this section, which apply to the selected Component.
+#. **Inline editor** - formatting you apply to individual characters or words with the CKEditor inline toolbar when you double click a text Component.
+
+Use the Component typography controls to fine-tune headings, paragraphs, and other text elements in legacy Themes that lack modern styling flexibility.
 
 Custom fonts
-************
+============
 
-From Mautic 5.x you can extend the Style Manager > Typography > Fonts list to include custom fonts.
+You can extend the **Typography** > **Fonts** list to include custom fonts.
 
 .. image:: images/editorfonts.jpg
   :width: 280

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -168,7 +168,7 @@ Mautic resolves typography across three levels, where each level overrides the o
 
 #. **Theme defaults** - the base styles defined by the Theme.
 #. **Component typography** - the Style Manager settings listed in this section, which apply to the selected Component.
-#. **Inline editor** - formatting you apply to individual characters or words with the CKEditor inline toolbar when you double click a text Component.
+#. **Inline editor** - the formatting you apply to individual characters or words with the CKEditor inline toolbar when you double click a text Component.
 
 Use the Component typography controls to fine-tune headings, paragraphs, and other text elements in legacy Themes that lack modern styling flexibility.
 

--- a/docs/builders/email_landing_page.rst
+++ b/docs/builders/email_landing_page.rst
@@ -147,7 +147,7 @@ Themes
 
 If you search through the list of available Themes, the new MJML Themes ``Brienz``, ``Paprika`` and ``Confirm Me`` display only with the new Builder.
 
-To learn more about creating Themes please :doc:`check the documentation</builders/creating_themes>`.
+To learn more about creating Themes, see :doc:`/builders/creating_themes`.
 
 Typography
 **********


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/9f7d8077-6ec8-4a62-8a9f-8f5a0cc870e1)

Ports PR #755's GrapesJS Builder docs to the 7.2 branch: adds an "Editing text" section (inline CKEditor, double click to edit, formatting options, paste from Word/Google Docs) and a "Typography" section (Style Manager controls plus the three typography override levels), and rewords the Custom fonts subsection. Also adds CKEditor and strikethrough to the Vale accept vocabulary. Documents mautic/mautic PR #15839 and PR #16098. Separate suggestion from #755, requested by @adiati98.

---

_Tip: Use Vale? Point your collection at your vale.ini in [Configuration](https://app.gopromptless.ai/configuration)._