### PR TITLE
docs: Document Segment filter for Form submissions

### DIFF
--- a/docs/segments/manage_segments.rst
+++ b/docs/segments/manage_segments.rst
@@ -329,6 +329,36 @@ Configuring Segment filters
 
 .. vale off
 
+Filtering by Form submissions
+=============================
+
+.. vale on
+
+You can create dynamic Segments based on which Forms your Contacts have submitted. This filter is available under **Contact behavior and actions** in the filter dropdown.
+
+1. Create or edit a Segment and go to the **Filters** tab.
+
+2. Click the **Choose one**… menu and search for 'Submitted a specific form' under **Contact behavior and actions**.
+
+3. Select an operator:
+
+   * **empty** - includes Contacts who haven't submitted any Forms
+   * **not empty** - includes Contacts who've submitted at least one Form
+   * **including any of** - includes Contacts who've submitted at least one of the selected Forms
+   * **excluding any of** - includes Contacts who haven't submitted any of the selected Forms
+   * **including all of** - includes Contacts who've submitted all of the selected Forms
+   * **excluding all of** - includes Contacts who haven't submitted all of the selected Forms
+
+4. If using an operator other than **empty** or **not empty**, select one or more Forms from the dropdown list.
+
+5. Click **Save and close**.
+
+.. tip::
+
+   Use this filter to target Contacts who've shown interest in specific topics or offers. For example, create a Segment of Contacts who've submitted your 'Free Trial Request' Form to send them follow-up information.
+
+.. vale off
+
 Using Date Filters
 ==================
 

--- a/docs/segments/manage_segments.rst
+++ b/docs/segments/manage_segments.rst
@@ -345,9 +345,9 @@ You can create dynamic Segments based on which Forms your Contacts have submitte
    * **empty** - includes Contacts who haven't submitted any Forms
    * **not empty** - includes Contacts who've submitted at least one Form
    * **including any of** - includes Contacts who've submitted at least one of the selected Forms
-   * **excluding any of** - includes Contacts who haven't submitted any of the selected Forms
+   * **excluding any of** - includes Contacts who've submitted none of the selected Forms
    * **including all of** - includes Contacts who've submitted all of the selected Forms
-   * **excluding all of** - includes Contacts who haven't submitted all of the selected Forms
+   * **excluding all of** - includes Contacts who haven't submitted the complete set of selected Forms. Contacts are missing at least one, so those who've submitted some but not all are still included
 
 4. If using an operator other than **empty** or **not empty**, select one or more Forms from the dropdown list.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/322b5388-af07-4992-9c0e-49f031750b1e)

Documents the new 'Submitted a specific form' Segment filter introduced in [PR #15964](https://github.com/mautic/mautic/pull/15964).

## Changes

### segments/manage_segments.rst
- **New section: Filtering by Form submissions** - Documents the new filter available under 'Contact behavior and actions' that allows building Segments based on Form submission history
- Lists all available operators: empty, not empty, including any of, excluding any of, including all of, excluding all of
- Includes step-by-step instructions for using the filter
- Adds a tip with a practical use case example

**Trigger Events**
- [mautic/mautic PR #15964: Add segment filter for form submissions](https://github.com/mautic/mautic/pull/15964)

---

_Tip: Enable auto-create PR in your [Configuration](https://app.gopromptless.ai/configuration) to review suggestions directly in GitHub 🤖_