### PR TITLE
docs: Backport Email Report columns and Unsubscribe-to-Open Ratio (UTOR) to 7.2

### DIFF
--- a/docs/reports/reports.rst
+++ b/docs/reports/reports.rst
@@ -98,6 +98,40 @@ The **Details** tab on a Report contains the same options across all Reports and
 
 .. vale on
 
+.. vale off
+
+Email Report columns
+--------------------
+
+.. vale on
+
+When using 'Emails' as the data source, you can add the following columns to measure Email engagement:
+
+.. vale off
+
+* **Sent count:** the number of Emails sent to Contacts.
+* **Read count:** the number of Emails that Contacts opened.
+* **Read ratio:** the percentage of sent Emails that Contacts opened.
+* **Click-through count:** the number of unique Contacts who clicked any link in the Email.
+* **Click-through rate:** the percentage of sent Emails that resulted in at least one click.
+* **Click-to-open rate:** the percentage of opened Emails that resulted in at least one click. This helps you understand how engaging the Email content is to recipients who already opened it.
+* **Unsubscribed:** the number of Contacts who unsubscribed after receiving the Email.
+* **Unsubscribed ratio:** the percentage of sent Emails that resulted in an unsubscribe.
+* **Unsubscribe-to-Open Ratio:** the percentage of unsubscribed Contacts relative to those who opened the Email. This helps you understand how Email content affects unsubscribe rates among engaged recipients.
+* **Bounced:** the number of Emails that bounced.
+* **Bounced ratio:** the percentage of sent Emails that bounced.
+* **Clicks:** the total number of link clicks across all recipients - non-unique.
+* **Clicks ratio:** the percentage of sent Emails that resulted in a click, based on total clicks rather than unique Contacts.
+* **Unique clicks:** the total number of unique clicks across all trackable links. Each link counts separately, so a Contact clicking multiple different links adds multiple unique clicks. If you need the number of unique Contacts who clicked any link, use **Click-through count** instead.
+* **Unique clicks ratio:** the percentage of sent Emails that resulted in a unique click, based on summed per-link unique hits.
+* **DNC Preferences:** summary of all Do Not Contact preferences for the Contact across all Channels and Emails.
+
+.. vale on
+
+.. tip::
+
+   Use the Unsubscribe-to-Open Ratio to compare the unsubscribe impact of different Emails. A high ratio may indicate that the Email content didn't meet recipient expectations, while a low ratio suggests it resonated with those who read it.
+
 
 Data
 ====


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/ed772667-79de-49e7-ac8e-94e94561db10)

Backports user-documentation PR #702 to the 7.2 branch. Adds an "Email Report columns" section to docs/reports/reports.rst documenting the engagement columns available when using the Emails data source — including the new Unsubscribe-to-Open Ratio (UTOR) stat — plus a tip on interpreting it.

**Trigger Events**
- New Task: Please apply the same changes made in https://github.com/mautic/user-documentation/pull/702 for branch 7.2.

## Linked issue

Closes #730

---

_Tip: Assign suggestions to team members in the [Promptless dashboard](https://app.gopromptless.ai) to claim work 👥_