### PR TITLE
docs: Document mautic:campaigns:summarize command with --campaign-id option

### DIFF
--- a/docs/configuration/command_line_interface.rst
+++ b/docs/configuration/command_line_interface.rst
@@ -91,7 +91,10 @@ These are the commands you may need to use in relation to your Mautic instance. 
      - ``mautic:campaigns:update``
    * - ``mautic:campaigns:trigger``
      - Trigger timed events for active Campaigns.
-     - 
+     -
+   * - ``mautic:campaigns:summarize``
+     - Build summary statistics for Campaign events. Supports ``--campaign-id`` to process a single Campaign.
+     -
    * - ``mautic:campaigns:validate``
      - Validate if a Contact has been inactive for a decision and execute events if so.
      - 

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -214,7 +214,7 @@ It's possible to download the database manually through Mautic's Configuration o
 Clean up old data cron job
 ==========================
 
-Clean up a Mautic installation by purging old data. Note that you can't purge some types of data within Mautic. 
+Clean up a Mautic installation by purging old data. Note that you can't purge some types of data within Mautic.
 Currently supported are audit log entries, visitors - anonymous Contacts - and visitor Landing Page hits. Use ``--dry-run`` to view the number of records impacted before making any changes.
 
 Use the ``--gdpr`` flag to delete data to fulfill GDPR European regulation. This deletes Contacts that have been inactive for 3 years.
@@ -224,6 +224,44 @@ Use the ``--gdpr`` flag to delete data to fulfill GDPR European regulation. This
 .. code-block:: php
 
     php /path/to/mautic/bin/console mautic:maintenance:cleanup --days-old=365 --dry-run
+
+.. vale off
+
+Rebuild Campaign summary statistics cron job
+============================================
+
+.. vale on
+
+The Campaign summary statistics command builds summary data from Campaign event logs. This is useful for fixing incorrect Campaign statistics in the UI without recalculating all Campaigns.
+
+.. code-block:: php
+
+    php /path/to/mautic/bin/console mautic:campaigns:summarize
+
+Command parameters
+------------------
+
+- ``--campaign-id=ID`` - process only a specific Campaign. When provided, the command resumes from that Campaign's own summary history instead of using global dates.
+
+- ``--rebuild`` - rebuild existing summary data from the current hour, walking backward through history. Without this flag, the command continues from where it last stopped.
+
+- ``--batch-limit=X`` - how many hours to process per batch.
+
+- ``--max-hours=X`` - maximum hours to process per execution.
+
+**Examples:**
+
+To rebuild summary statistics for a single Campaign:
+
+.. code-block:: bash
+
+    php /path/to/mautic/bin/console mautic:campaigns:summarize --campaign-id=434
+
+To fully rebuild a Campaign's statistics from scratch:
+
+.. code-block:: bash
+
+    php /path/to/mautic/bin/console mautic:campaigns:summarize --campaign-id=434 --rebuild
 
 MaxMind CCPA compliance cron job
 ================================

--- a/docs/configuration/cron_jobs.rst
+++ b/docs/configuration/cron_jobs.rst
@@ -227,7 +227,7 @@ Use the ``--gdpr`` flag to delete data to fulfill GDPR European regulation. This
 
 .. vale off
 
-Rebuild Campaign summary statistics cron job
+Rebuild Campaign summary statistics Cron job
 ============================================
 
 .. vale on
@@ -241,13 +241,10 @@ The Campaign summary statistics command builds summary data from Campaign event 
 Command parameters
 ------------------
 
-- ``--campaign-id=ID`` - process only a specific Campaign. When provided, the command resumes from that Campaign's own summary history instead of using global dates.
-
-- ``--rebuild`` - rebuild existing summary data from the current hour, walking backward through history. Without this flag, the command continues from where it last stopped.
-
-- ``--batch-limit=X`` - how many hours to process per batch.
-
-- ``--max-hours=X`` - maximum hours to process per execution.
+* ``--campaign-id=ID`` - Process only a specific Campaign. When provided, the command resumes from that Campaign's own summary history instead of using global dates.
+* ``--rebuild`` - Rebuild existing summary data from the current hour, walking backward through history. Without this flag, the command continues from where it last stopped.
+* ``--batch-limit=X`` - How many hours to process per batch.
+* ``--max-hours=X`` - Maximum hours to process per execution.
 
 **Examples:**
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/164ace01-247b-47dc-a185-f5ce4f35a6bc)

Adds documentation for the mautic:campaigns:summarize CLI command, including the new --campaign-id option for rebuilding Campaign summary statistics for a single Campaign.

**Trigger Events**
- [mautic/mautic PR #16049: Add campaign filter to summarize command](https://github.com/mautic/mautic/pull/16049)

---

_Tip: Add or adjust Promptless's style guide in [Agent Knowledge Base](https://app.gopromptless.ai/configure/settings) ✍️_