### PR TITLE
docs: Document customizable slot labels for Preference Center

### DIFF
--- a/docs/contacts/preference_center.rst
+++ b/docs/contacts/preference_center.rst
@@ -148,9 +148,11 @@ Customizing slot labels
 
 .. vale on
 
-When building custom Themes for Preference Center pages, you can override the default text labels for each slot. This lets you customize wording to match your branding or provide translations for different languages.
+When building custom Themes for Preference Center Landing Pages, you can override the default text labels for each slot. This lets you customize wording to match your branding or provide translations for different languages.
 
 The following parameters are available for customizing slot labels in your Theme's Twig templates:
+
+.. vale off
 
 .. list-table::
    :widths: 30 30 40
@@ -187,10 +189,12 @@ The following parameters are available for customizing slot labels in your Theme
      - ``saveprefsbutton['btnText']``
      - Text displayed on the save button
 
+.. vale on
+
 If you don't provide a custom value for these parameters, Mautic uses the default translated strings.
 
 .. note::
-   These customization parameters are for use in custom Theme development. See the Mautic Developer Documentation for implementation details on creating custom Preference Center Themes.
+   These customization parameters are for use in custom Theme development. See `Getting started with Themes <https://devdocs.mautic.org/en/latest/themes/getting_started.html>`_ in the Mautic Developer Documentation for implementation details on creating custom Themes for Preference Center Landing Pages.
 
 .. vale off
 

--- a/docs/contacts/preference_center.rst
+++ b/docs/contacts/preference_center.rst
@@ -172,19 +172,19 @@ The following parameters are available for customizing slot labels in your Theme
      - Label for the preferred channel dropdown
    * - Channel Frequency
      - ``channelfrequency['label-text']``
-     - Label for the 'I want to receive' checkbox
+     - Label for the **I want to receive** checkbox
    * - Channel Frequency
      - ``channelfrequency['label-text1']``
-     - Label for the 'Do not contact more than' setting
+     - Label for the **Do not contact more than** setting
    * - Channel Frequency
      - ``channelfrequency['label-text2']``
-     - Label for the 'Messages each' frequency option
+     - Label for the **Messages each** frequency option
    * - Channel Frequency
      - ``channelfrequency['label-text3']``
-     - Label for the 'Pause from' date setting
+     - Label for the **Pause from** date setting
    * - Channel Frequency
      - ``channelfrequency['label-text4']``
-     - Label for the 'Pause to' date setting
+     - Label for the **Pause to** date setting
    * - Save Preferences Button
      - ``saveprefsbutton['btnText']``
      - Text displayed on the save button
@@ -194,6 +194,7 @@ The following parameters are available for customizing slot labels in your Theme
 If you don't provide a custom value for these parameters, Mautic uses the default translated strings.
 
 .. note::
+
    These customization parameters are for use in custom Theme development. See the :xref:`Themes` section of the Developer Documentation for implementation details on creating custom Themes for Preference Center Landing Pages.
 
 .. vale off

--- a/docs/contacts/preference_center.rst
+++ b/docs/contacts/preference_center.rst
@@ -141,7 +141,58 @@ In addition, add a **Save preferences** button if you wish to save the preferenc
 
 Save your changes, and the Preference Center Landing Page is ready.
 
-.. vale off 
+.. vale off
+
+Customizing slot labels
+=======================
+
+.. vale on
+
+When building custom Themes for Preference Center pages, you can override the default text labels for each slot. This lets you customize wording to match your branding or provide translations for different languages.
+
+The following parameters are available for customizing slot labels in your Theme's Twig templates:
+
+.. list-table::
+   :widths: 30 30 40
+   :header-rows: 1
+
+   * - Slot
+     - Parameter
+     - Description
+   * - Category List
+     - ``categorylist['label-text']``
+     - Label for the category list section heading
+   * - Segment List
+     - ``segmentlist['label-text']``
+     - Label for the Segment list section heading
+   * - Preferred Channel
+     - ``preferredchannel['label-text']``
+     - Label for the preferred channel dropdown
+   * - Channel Frequency
+     - ``channelfrequency['label-text']``
+     - Label for the 'I want to receive' checkbox
+   * - Channel Frequency
+     - ``channelfrequency['label-text1']``
+     - Label for the 'Do not contact more than' setting
+   * - Channel Frequency
+     - ``channelfrequency['label-text2']``
+     - Label for the 'Messages each' frequency option
+   * - Channel Frequency
+     - ``channelfrequency['label-text3']``
+     - Label for the 'Pause from' date setting
+   * - Channel Frequency
+     - ``channelfrequency['label-text4']``
+     - Label for the 'Pause to' date setting
+   * - Save Preferences Button
+     - ``saveprefsbutton['btnText']``
+     - Text displayed on the save button
+
+If you don't provide a custom value for these parameters, Mautic uses the default translated strings.
+
+.. note::
+   These customization parameters are for use in custom Theme development. See the Mautic Developer Documentation for implementation details on creating custom Preference Center Themes.
+
+.. vale off
 
 Accessing Preference Center Pages
 *********************************

--- a/docs/contacts/preference_center.rst
+++ b/docs/contacts/preference_center.rst
@@ -194,7 +194,7 @@ The following parameters are available for customizing slot labels in your Theme
 If you don't provide a custom value for these parameters, Mautic uses the default translated strings.
 
 .. note::
-   These customization parameters are for use in custom Theme development. See `Getting started with Themes <https://devdocs.mautic.org/en/latest/themes/getting_started.html>`_ in the Mautic Developer Documentation for implementation details on creating custom Themes for Preference Center Landing Pages.
+   These customization parameters are for use in custom Theme development. See the :xref:`Themes` section of the Developer Documentation for implementation details on creating custom Themes for Preference Center Landing Pages.
 
 .. vale off
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/fc00234b-9dbe-4e97-90a7-789641d60caa)

Documents the new label customization parameters available in Preference Center slot templates. Theme developers can now override default text labels for category lists, segment lists, preferred channel dropdowns, channel frequency settings, and the save button to match their branding or provide translations.

**Trigger Events**
- [mautic/mautic PR #16041: Preference center page improvements](https://github.com/mautic/mautic/pull/16041)

---

_Tip: Planning a big docs refactor? Use [Deep Analysis](https://app.gopromptless.ai/new-task?deep_analysis=true) to get help with the heavy lifting._