### PR TITLE
docs: Document required Subject field for Send Email to Contact (7.2)

### DIFF
--- a/docs/contacts/manage_contacts.rst
+++ b/docs/contacts/manage_contacts.rst
@@ -368,7 +368,13 @@ Send Email to Contact
 
 .. vale on
 
-This option enables Users to send an individual Email, either manually created with the builder or from a template Email. The **From Name** and **From Email Address** default to the User sending the individual message.
+This option lets Users send an individual Email, either manually created with the builder or from a template Email. The **From Name** and **From Email Address** default to the User sending the message.
+
+.. vale off
+
+Enter a **Subject** when you send the Email. If you leave it empty, Mautic displays the error 'A subject is required.'
+
+.. vale on
 
 .. _Contact tracking:
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/764cd5c3-81ad-4bad-a3ea-fbf432ae09de)

Replicates the approved 7.1 change from PR #804 on the 7.2 branch, per @adiati98's request. Documents that a Subject is required when sending a custom Email to a Contact via the Contact detail page, based on [PR #15883](https://github.com/mautic/mautic/pull/15883), with the verbatim UI error string wrapped in Vale off/on directives.

---

_Tip: Planning a big docs refactor? Use [Deep Analysis](https://app.gopromptless.ai/new-task?deep_analysis=true) to get help with the heavy lifting._