### PR TITLE
docs: Update default Contact social field tokens (X, TikTok, YouTube) in variables reference

### DIFF
--- a/docs/configuration/variables.rst
+++ b/docs/configuration/variables.rst
@@ -78,10 +78,6 @@ See :doc:`managing custom fields </contacts/custom_fields>` for more information
      - ``{contactfield=fax}``
    * - First Name
      - ``{contactfield=firstname}``
-   * - Foursquare
-     - ``{contactfield=foursquare}``
-   * - Google+
-     - ``{contactfield=googleplus}``
    * - Instagram
      - ``{contactfield=instagram}``
    * - IP Address
@@ -96,19 +92,21 @@ See :doc:`managing custom fields </contacts/custom_fields>` for more information
      - ``{contactfield=phone}``
    * - Position
      - ``{contactfield=position}``
-   * - Skype
-     - ``{contactfield=skype}``
    * - State
      - ``{contactfield=state}``
-   * - Twitter
+   * - TikTok
+     - ``{contactfield=tiktok}``
+   * - X
      - ``{contactfield=twitter}``
    * - Title
      - ``{contactfield=title}``
    * - Website
      - ``{contactfield=website}``
+   * - YouTube
+     - ``{contactfield=youtube}``
    * - Zip Code
      - ``{contactfield=zipcode}``
-  
+
 Contact Owner fields
 *********************
   
@@ -392,10 +390,6 @@ Alphabetical list
      - ``{contactfield=companyfax}`` 
    * - First Name
      - ``{contactfield=firstname}``
-   * - Foursquare
-     - ``{contactfield=foursquare}``
-   * - Google+
-     - ``{contactfield=googleplus}``
    * - Instagram
      - ``{contactfield=instagram}``
    * - IP Address
@@ -429,17 +423,19 @@ Alphabetical list
    * - Segment List (Preference Center)
      - ``{segmentlist}`` 
    * - Signature
-     - ``{signature}`` 
-   * - Skype
-     - ``{contactfield=skype}``
+     - ``{signature}``
    * - State
      - ``{contactfield=state}``
    * - State (Company)
      - ``{contactfield=companystate}``
    * - Subject
-     - ``{subject}`` 
-   * - Twitter
+     - ``{subject}``
+   * - TikTok
+     - ``{contactfield=tiktok}``
+   * - X
      - ``{contactfield=twitter}``
+   * - YouTube
+     - ``{contactfield=youtube}``
    * - Preferred Channel (Preference Center)
      - ``{preferredchannel}``
    * - Resubscribe URL


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/ee214ee4-6d10-4a8d-afcf-013e4030a45c)

Aligns the Contact field token tables in docs/configuration/variables.rst with mautic/mautic PR #16413: removes the Foursquare, Google+, and Skype tokens, renames Twitter to X (the {contactfield=twitter} alias is unchanged), and adds TikTok and YouTube tokens. Targets the 7.2 user docs branch per the LTC branch-targeting table.

**Trigger Events**
- [mautic/mautic PR #16413: feat(contact): update default social media fields](https://github.com/mautic/mautic/pull/16413)

---

_Tip: Attach PDFs in Slack messages to Promptless—it can even extract images from them 📎_