### PR TITLE
docs: Document SAML password hiding and login retry screen (7.2)

### DIFF
--- a/docs/authentication/authentication.rst
+++ b/docs/authentication/authentication.rst
@@ -32,38 +32,50 @@ To turn on SAML support in Mautic, you first need the IDP's metadata XML which t
   :width: 800
   :alt: Screenshot of the User Role Permission
 
+.. vale off
+
 Configuring the IDP
 ===================
+
+.. vale on
+
 The IDP may ask for the following settings:
 
-#. Entity ID - this is site URL, displayed at the top of User/Authentication Settings. Copy this exactly 'as is' to the IDP.
+.. vale off
 
-#. Service Provider Metadata - if the provider requires a URL, use ``https://example.com/saml/metadata.xml``. To use as a file rather than a URL, browse to that URL and save the content as an XML file.
+#. **Entity ID** - This is the site URL, displayed at the top of **User/Authentication Settings**. Copy this exactly as is to the IDP.
 
-#. Assertion Consumer Service - Use ``https://example.com/s/saml/login_check``.
+   .. note::
 
-#. Issuer - this should come from the IDP but is often configurable. If it's a URL, be sure that the scheme - ``http://`` and ``https://`` - aren't part of it.
+      If you use a custom domain, set the site URL in **Configuration** > **System Settings** to match it. This keeps your SAML setup working correctly.
 
-#. Verify request signatures or a SSL certificate - If the IDP supports encrypting and validating request signatures from Mautic to the IDP, generate a self signed SSL certificate. Upload the certificate and private key through Mautic's Configuration > User/Authentication Settings under the 'Use a custom X.509 certificate and private key to secure communication between Mautic and the IDP' section. Then upload the certificate to the IDP.
+#. **Service Provider Metadata** - If the provider requires a URL, use ``https://example.com/saml/metadata.xml``. If it needs a file instead of a URL, open the URL in a browser and save the content as an XML file.
+#. **Assertion Consumer Service** - Use ``https://example.com/s/saml/login_check``.
+#. **Issuer** - It should come from the IDP but is often configurable. If it's a URL, be sure that the scheme - ``http://`` or ``https://`` - isn't part of it.
+#. **Verify request signatures or an SSL certificate** - If the IDP supports encrypting and validating request signatures from Mautic to the IDP, generate a self-signed SSL certificate. Upload the certificate and private key through Mautic's **Configuration** > **User/Authentication Settings** under the "**Use a custom X.509 certificate and private key to secure communication between Mautic and the IDP**" section. Then upload the certificate to the IDP.
+#. **Custom attributes** - Mautic requires three custom attributes in the IDP responses - email, first name, and last name - and can optionally include a username. Configure the attribute names used by the IDP in Mautic's **Configuration** > **User/Authentication Settings** under the "**Enter the names of the attributes the configured IDP uses for the following Mautic User fields**" section.
 
-#. Custom attributes - Mautic requires three custom attributes in the IDP responses for the User Email, first name and last name. Username is also supported but is optional. Configure the attribute names used by the IDP in Mautic's Configuration > User/Authentication Settings under the 'Enter the names of the attributes the configured IDP uses for the following Mautic User fields' section.
+.. vale on
+
+.. vale off
 
 Example - Azure SAML SSO
 ========================
 
-1) Register new Enterprise applications by navigating to ``Create your own Application`` and then ``Integrate any other application you don't find in the gallery (Non-gallery)``
-2) Go to Single Sign-On
-3) ``Identifier (Entity ID)`` - this is the site URL located at the top of User/Authentication Settings. Copy this exactly as is to the IDP.
-4) ``Reply URL (Assertion Consumer Service URL)`` - Use ``https://example.com/s/saml/login_check``
-5) Download Federation Metadata XML from 3. SAML Certificates
-6) Upload the downloaded Federation Metadata XML to Mautic
-7) X.509-Certificate isn't required
-8) Use the following for the custom attributes fields:
+#. Register a new application by going to **Enterprise Applications**, clicking **Create your own application**, and selecting **Integrate any other application you don't find in the gallery (Non-gallery)**.
+#. Go to the **Single sign-on** menu.
+#. **Entity ID** - This is the site URL, displayed at the top of **User/Authentication Settings**. Copy this exactly as is to the IDP.
+#. **Reply URL (Assertion Consumer Service URL)** - Use ``https://example.com/s/saml/login_check``.
+#. In the **SAML Certificates** section, download the **Federation Metadata XML**.
+#. Upload the downloaded **Federation Metadata XML** file to the **Identity provider metadata file** field in Mautic, and leave the **X.509 Certificate** field blank.
+#. Use the following for the custom attributes fields:
 
-E-Mail: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``
-First Name: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname``
-Last Name: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname``
-Username (optional): ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``
+   * **E-Mail**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``
+   * **First Name**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname``
+   * **Last Name**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname``
+   * **Username (optional)**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``
+
+.. vale on
 
 Logging in
 ==========
@@ -71,6 +83,28 @@ Logging in
 Once configured with the IDP and the IDP with Mautic, Mautic redirects all logins to the IDP's login. ``/s/login`` is still available for direct logins but you have to access it directly.
 
 Login to the IDP, which then redirects you back to Mautic. If the exchange is successful Mautic creates a User if it doesn't already exist, and logs the User into the system.
+
+.. vale off
+
+Managing passwords for SAML-authenticated Users
+===============================================
+
+.. vale on
+
+.. vale off
+
+Mautic hides the password fields on the Account page and User edit form for SAML-authenticated Users. SAML-authenticated Users log in through the identity provider, so they manage their passwords there, not in Mautic.
+
+.. vale on
+
+Recovering from a login error
+=============================
+
+.. vale off
+
+A SAML login can fail if the session expires or if Mautic receives an unexpected response from the IDP, such as the intermittent 'Unknown Response' error. When this happens, Mautic clears the session and shows a retry screen. Select the login button to try again. If the error keeps happening, contact your administrator.
+
+.. vale on
 
 Turning off SAML
 ================

--- a/docs/authentication/authentication.rst
+++ b/docs/authentication/authentication.rst
@@ -73,7 +73,7 @@ Example - Azure SAML SSO
    * **E-Mail**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``
    * **First Name**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname``
    * **Last Name**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname``
-   * **Username (optional)**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``
+   * **Username (optional)**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name``
 
 .. vale on
 

--- a/docs/users_roles/managing_users.rst
+++ b/docs/users_roles/managing_users.rst
@@ -32,9 +32,17 @@ To set up a User manually:
   
    * **Username, Email, Password** are the login credentials. If a User forgets their password, they can use the Forgot password link, but you can manually change their password here.
   
-.. note:: 
+.. note::
 
     Passwords must be at least six characters in length. Ensure that you use a combination of upper and lower case alphabets, special characters, and numbers.
+
+.. note::
+
+   .. vale off
+
+   When you log in through SAML, Mautic hides the password fields on the User add and edit forms. SAML Users manage their passwords in the identity provider, not in Mautic. For more information, see :doc:`SAML Single Sign On </authentication/authentication>`.
+
+   .. vale on
 
 * **Time zone** - Set the User's time zone, or use the default. Adding the User's time zone enables them to account for time zone differences for Email scheduling and other features.
 

--- a/docs/users_roles/managing_users.rst
+++ b/docs/users_roles/managing_users.rst
@@ -46,7 +46,13 @@ To set up a User manually:
 
    * **Language** - Select a language for each User, to improve their experience in Mautic.
 
-When creating your Users, inform them of the credentials. Mautic doesn't send an Email notifying Users of their login information. Manually informing them is necessary.
+.. important::
+
+   .. vale off
+
+   Once you create Users, give them their credentials directly because Mautic doesn't send emails with their login information.
+
+   .. vale on
 
 .. vale off
 

--- a/docs/users_roles/managing_users.rst
+++ b/docs/users_roles/managing_users.rst
@@ -42,9 +42,9 @@ To set up a User manually:
 
         .. vale on
 
-* **Time zone** - Set the User's time zone, or use the default. Adding the User's time zone enables them to account for time zone differences for Email scheduling and other features.
+   * **Time zone** - Set the User's time zone, or use the default. Adding the User's time zone enables them to account for time zone differences for Email scheduling and other features.
 
-* **Language** - Select a language for each User, to improve their experience in Mautic. 
+   * **Language** - Select a language for each User, to improve their experience in Mautic.
 
 When creating your Users, inform them of the credentials. Mautic doesn't send an Email notifying Users of their login information. Manually informing them is necessary.
 

--- a/docs/users_roles/managing_users.rst
+++ b/docs/users_roles/managing_users.rst
@@ -32,7 +32,7 @@ To set up a User manually:
   
    * **Username, Email, Password** are the login credentials. If a User forgets their password, they can use the Forgot password link, but you can manually change their password here.
 
-     Passwords must be at least six characters in length. Ensure that you use a combination of upper and lower case alphabets, special characters, and numbers.
+     Passwords must be **at least six characters** in length. Ensure that you use a combination of upper and lower case alphabets, special characters, and numbers.
 
      .. note::
 

--- a/docs/users_roles/managing_users.rst
+++ b/docs/users_roles/managing_users.rst
@@ -31,18 +31,16 @@ To set up a User manually:
    * **Position - optional** - Your User's job title.
   
    * **Username, Email, Password** are the login credentials. If a User forgets their password, they can use the Forgot password link, but you can manually change their password here.
-  
-.. note::
 
-    Passwords must be at least six characters in length. Ensure that you use a combination of upper and lower case alphabets, special characters, and numbers.
+     Passwords must be at least six characters in length. Ensure that you use a combination of upper and lower case alphabets, special characters, and numbers.
 
-.. note::
+     .. note::
 
-   .. vale off
+        .. vale off
 
-   When you log in through SAML, Mautic hides the password fields on the User add and edit forms. SAML Users manage their passwords in the identity provider, not in Mautic. For more information, see :doc:`SAML Single Sign On </authentication/authentication>`.
+        When you log in through SAML, Mautic hides the password fields on the User add and edit forms. SAML Users manage their passwords in the identity provider, not in Mautic. For more information, see :doc:`SAML Single Sign On </authentication/authentication>`.
 
-   .. vale on
+        .. vale on
 
 * **Time zone** - Set the User's time zone, or use the default. Adding the User's time zone enables them to account for time zone differences for Email scheduling and other features.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/65054361-e675-4d66-9c48-d90a9402f3bd)

Cherry-pick of docs PR #819 for the 7.2 branch. Documents user-facing SAML behaviors from mautic/mautic#15508 — password field hiding for SAML-authenticated Users and the login retry/error-recovery screen — plus @adiati98's approved review cleanups to docs/authentication/authentication.rst and docs/users_roles/managing_users.rst. Faithful copy of #819's final approved state, based on 7.2.

---

_Tip: Worried about broken links? Ask Promptless to find and fix them automatically 🔗_