### PR TITLE
fix: Incorrect claim for `username`

### DIFF
--- a/docs/authentication/authentication.rst
+++ b/docs/authentication/authentication.rst
@@ -73,7 +73,7 @@ Example - Azure SAML SSO
    * **E-Mail**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``
    * **First Name**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname``
    * **Last Name**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname``
-   * **Username (optional)**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``
+   * **Username (optional)**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name``
 
 .. vale on
 


### PR DESCRIPTION
## Description

This PR fixes incorrect claim for `username`.

### Before

* **Username (optional)**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``

### After

* **Username (optional)**: ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name``


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

Clearly describe what changes you have made in this PR, where our maintainers or reviewers should look at, and how to test the changes.

If the request is not complete but you want feedback or have quetions, you can select the "Draft Pull Request" option from the dropdown menu when creating the PR, then ask your questions or write your feedback in the comment.

-->

## Linked issue

N/A


<!-- PLEASE WRITE ABOVE THIS COMMENT. -->

<!--

If your PR is related to a current issue, please link to that issue number. Type the keyword "Closes" followed by a hashtag (#) symbol and the issue number that you can find right after the issue title. Don't add anything else, such as period, comma, etc, to this. For example:

❌ Closes: #123.

✅ Closes #123

Doing so will automatically close the issue when one of our maintainers merges your PR.

-->

## Screenshots or screen recordings

<!-- 

Provide screenshots or screen recordings before and after the changes, if it's a UI changes. You can simply drag and drop your files above this comment.

-->