### PR TITLE
docs: Cherry-pick automatic tracking filtering docs to 7.1

### DIFF
--- a/.github/styles/config/vocabularies/Mautic/accept.txt
+++ b/.github/styles/config/vocabularies/Mautic/accept.txt
@@ -105,6 +105,8 @@ Pipedrive
 Piwik
 POST
 post
+prefetch
+prerender
 PUT
 Rackspace
 Remarketing

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -730,6 +730,27 @@ Mautic tracking settings
   * The tracking code automatically detects the Preferred Timezone and Preferred Locale fields.
   * Landing Pages including 4-byte UTF-8 characters, such as emojis and some Chinese or other non-Latin characters, in the Landing Page title or URL aren't tracked on a Contact's activity history in Mautic. Mautic tracks all Latin characters used in English and other western languages which are of 1-byte.
 
+Automatic tracking filtering
+============================
+
+.. vale off
+
+To keep your analytics focused on real people, Mautic automatically excludes certain requests from tracking. When a request matches any of the conditions below, Mautic doesn't record the page hit, Email open, Asset download, or Contact tracking activity:
+
+.. vale on
+
+.. vale off
+
+* **Bots and crawlers** - Requests Mautic identifies as bots through the IP and User Agent filtering described in :ref:`Miscellaneous Settings<miscellaneous settings>`.
+* **HEAD requests** - Requests that use the ``HTTP HEAD`` method, which monitoring and uptime tools commonly send.
+* **Speculative loading requests** - The prefetch and prerender requests browsers make to load links a visitor hasn't actually opened.
+* **Global Privacy Control signals** - Requests that send a ``Sec-GPC: 1`` header. Honoring this signal is a legal requirement under privacy laws such as the California Consumer Privacy Act.
+* **Do Not Track signals** - Requests that send a ``DNT: 1`` header.
+
+.. vale on
+
+This filtering is always on, and you can't turn it off. Because Mautic doesn't track these requests, it doesn't create anonymous Contacts for them, so your analytics reflect genuine human engagement and respect visitor privacy preferences.
+
 Facebook pixel
 ==============
 

--- a/docs/contacts/contacts_overview.rst
+++ b/docs/contacts/contacts_overview.rst
@@ -43,6 +43,8 @@ If you have an IP lookup service :ref:`configured<miscellaneous settings>` in **
 
     * In **Settings > Configuration > Tracking Settings**, you can enable the **Do Not Track 404 error for anonymous Contacts** option to not track page hits on any 404 error page tracked by the tracking code. This option helps prevent tracking pages you're not interested in and filling the Contact logs with bot activity. See :ref:`Tracking settings<tracking settings>`
 
+    * Mautic also filters out bot, monitoring, and privacy opt-out traffic automatically, so it doesn't create anonymous Contacts for those requests. See :ref:`Automatic tracking filtering<automatic tracking filtering>`.
+
     * Data for anonymous Contacts isn't available for segmentation or reporting. Once identified, the data is available, which applies to non-Campaign based Dynamic Web Content filters.
 
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/374b2efe-5fba-4de5-a7eb-0eac478f1ce2)

Replicates the maintainer-approved changes from PR #796 (base 7.2) onto the 7.1 branch, per @adiati98's request. Adds an 'Automatic tracking filtering' subsection under Tracking settings in settings.rst, cross-references it from the Contacts overview, and adds 'prefetch'/'prerender' to the Mautic Vale vocabulary. Documents mautic/mautic#15844.

---

_Tip: Whenever you leave a comment tagged `@Promptless` on a Promptless PR, Promptless will remember it for future suggestions 🧠_