### PR TITLE
docs: Update Asset URL label and copy-link control in 'Viewing an Asset'

### DIFF
--- a/docs/components/assets.rst
+++ b/docs/components/assets.rst
@@ -117,9 +117,9 @@ Viewing an Asset
 
 .. vale on
 
-Once you've uploaded an Asset, you'll want to make it available for your Contacts to access it. Using the Download URL from the Asset section in Mautic, you can track which Contacts are downloading or viewing the Assets.
+Once you've uploaded an Asset, you'll want to make it available for your Contacts. The Asset details page shows the download link in the 'Asset URL' field. Select the 'Copy download link' button next to the field to copy the URL, so you can track which Contacts download or view the Asset.
 
-Copy and paste the link into your website, on a Landing Page, or as a link in an Email. 
+Paste the link into your website, on a Landing Page, or as a link in an Email.
 
 .. note:: 
     In a Mautic Email or Landing Page, append ``?stream=1`` to the end of the URL to open the Asset in a new tab.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/1bacb0e8-58da-4c85-9897-159f462a4ac0)

mautic/mautic PR #16605 renamed the Asset detail-page 'Download URL' label to 'Asset URL' and added a 'Copy download link' button. This updates the 'Viewing an Asset' section in assets.rst to reference the current label and control, fixing the now-stale 'Download URL' reference.

**Trigger Events**
- [mautic/mautic PR #16605: Allow to preview and copy all URLs for Asset, Landing page, Webhook, and Email detail pages](https://github.com/mautic/mautic/pull/16605)

---

_Tip: Point @Promptless at some of your docs debt and have it clean them up in the background 🧹_