### PR TITLE
Fix broken link check: ignore howtoforge cron guide URL (7.1)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,4 +99,6 @@ linkcheck_ignore = [
     r"https://developers.facebook.com/products/facebook-login/",
     # 403 client error from this domain
     r"https://www.vtiger.com/",
+    # 403 client error from this domain (anti-bot block; URL works in a browser)
+    r"https://www.howtoforge.com/a-short-introduction-to-cron-jobs",
 ]


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](<https://app.gopromptless.ai/suggestions/0b4a44e3-f78f-464a-af01-7ca90747d5bc>)

Running the project's `make checklinks` (Sphinx linkcheck) on the 7.1 branch surfaced one broken link: the Apache Foundation cron-jobs guide at howtoforge.com, referenced from `configuration/cron_jobs.rst`, returns a `403 Forbidden` to the automated checker. The page is live and correct in a browser — the 403 is an anti-bot block on the checker, not a dead link.

Per the Mautic community handbook's "Working with external links" guidance, a working URL that returns a non-404 error (403, timeout, anchor) should be added to `linkcheck_ignore` in `docs/conf.py` with an explanatory comment rather than replaced. This adds that single ignore entry, matching the existing convention in the list. The `:xref:` link itself is unchanged. After the change, `make checklinks` reports zero broken links on this branch.