### PR TITLE
Document consent-aware Focus Item embedding (split Focus scripts)

### DIFF
--- a/docs/channels/focus_items.rst
+++ b/docs/channels/focus_items.rst
@@ -200,7 +200,7 @@ Once you have created your Focus Item, you're ready to activate it to your websi
 Deploying to a website
 ======================
 
-When you save the Focus Item, Mautic shows the code required to display it on your website in a green box on the Focus Item overview. The install panel now presents these options in a tabbed panel with two embedding approaches - 'Consent-managed' and 'Full tracking'. The legacy single script snippet still works unchanged, so any Focus Item you've already embedded keeps working without changes.
+When you save the Focus Item, Mautic shows the code required to display it on your website in the 'Focus implementation' panel on the Focus Item overview. For external websites, the panel offers two options - 'Consent-managed' and 'Full tracking' - and it also provides copyable Landing Page tokens. The legacy single-script snippet still works, so previously embedded Focus Items keep working without any changes.
 
   .. image:: images/focus_items/focus_item_embed.png
     :width: 400
@@ -217,35 +217,44 @@ Consent-managed
 The 'Consent-managed' option gives you two pieces that you use together:
 
 * A *display* script that loads and shows the Focus Item without any Mautic tracking.
-* A *tracking activation* snippet that exposes a JavaScript callback named ``enableMauticFocusTracking{id}()``, where ``{id}`` is the Focus Item's ID. Your site's developer wires this callback into your consent-management platform (CMP) so that Focus tracking starts only after the visitor grants consent. Your site's developer makes this connection - it's a hand-off to your web development team.
+* A *tracking activation* snippet that calls Mautic's public ``window.MauticFocus.enableTracking(<id>)`` API, where ``<id>`` is the Focus Item's numeric ID. Calling it activates tracking for that Focus Item. Your site's developer runs this snippet from your consent-management platform (CMP) so Focus tracking starts only after the visitor grants consent. See the :xref:`Focus Item scripts docs` page in the Mautic Developer Documentation for the JavaScript API.
+
+.. code-block:: js
+
+   // run this from your consent-management platform once the visitor consents
+   window.MauticFocus.enableTracking(123);
 
 Use the 'Consent-managed' option when your site must wait for the visitor's consent decision before Focus tracking can start.
 
-Both the display script and the tracking activation snippet go on the page; only the *call* to ``enableMauticFocusTracking{id}()`` is gated by consent. If the visitor never consents, the callback is simply never called: the Focus Item still displays, and Mautic just doesn't track it.
+Both the display script and the tracking activation snippet go on the page. Only the *call* to ``window.MauticFocus.enableTracking(<id>)`` is gated by consent. If the visitor never consents, that call never runs: the Focus Item still displays, and Mautic just doesn't track it.
 
-Mautic doesn't collect, store, or prove consent - it only separates displaying the Focus Item from activating tracking. Your site's own consent mechanism controls when tracking starts.
+Mautic doesn't record or verify consent - it only separates displaying the Focus Item from activating tracking. Your site's own consent mechanism controls when tracking starts.
 
-If your Mautic administrator has turned on 'Use Mautic consent for Focus tracking' (see 'Bridging Mautic website-tracking consent' below), you don't need to wire ``enableMauticFocusTracking{id}()`` separately - the two approaches are alternatives.
+If your Mautic administrator has turned on 'Use Mautic consent for Focus tracking' (see 'Bridging Mautic website-tracking consent' below), you don't need to call ``window.MauticFocus.enableTracking(<id>)`` separately - the two approaches are alternatives.
 
 Full tracking
 ~~~~~~~~~~~~~
 
-The 'Full tracking' option is a single snippet that loads the display script and then immediately activates tracking. This is equivalent to the legacy embed behavior. Use it only when consent already exists at page load, or when you handle consent through another mechanism outside of Mautic.
+The 'Full tracking' option is a single snippet that loads the display script and then immediately activates tracking. This is equivalent to the legacy embed behavior. Use it only when consent already exists at page load, or when you handle consent through another mechanism outside of Mautic. As with the 'Consent-managed' option, your web development team places this snippet on the page.
 
 Bridging Mautic website-tracking consent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Mautic's global Configuration includes a 'Use Mautic consent for Focus tracking' option under Tracking Settings, turned off by default. See :doc:`/configuration/settings` for where to find it.
+This is a system-wide setting in Settings > Configuration (typically administrator-only), so you may need your Mautic administrator to review or change it. Mautic's global Configuration includes a 'Use Mautic consent for Focus tracking' option under Tracking Settings, turned off by default. See :doc:`/configuration/settings` for where to find it.
 
-When you turn this option on, the copied website-tracking snippet bridges the visitor's Mautic website-tracking consent to Focus tracking. Focus tracking then activates automatically once the visitor grants Mautic website-tracking consent, so you don't need to wire ``enableMauticFocusTracking{id}()`` into a separate CMP. This is the same consent that Mautic's website tracking script uses.
+When this option is on, the copied website-tracking snippet (Mautic's main site-tracking code, separate from the Focus Item embed) bridges the visitor's Mautic website-tracking consent to Focus tracking. Focus tracking then activates automatically once the visitor grants Mautic website-tracking consent, so you don't need to call ``window.MauticFocus.enableTracking(<id>)`` from a separate CMP. This is the same consent that Mautic's website tracking script uses.
 
-For the bridge to gate Focus tracking on consent, your website's own Mautic tracking must itself be set up as consent-managed; otherwise Focus tracking activates as soon as Mautic tracking loads. See :doc:`/configuration/tracking_script` for how to set up consent-managed website tracking.
+.. warning::
+
+   For the bridge to gate Focus tracking on consent, your website must itself manage Mautic tracking through consent. Otherwise, Focus tracking activates as soon as Mautic tracking loads, with no consent gating at all. See :doc:`/configuration/tracking_script` for how to set up consent-managed website tracking.
 
 This setting only affects Focus Items embedded with the 'Consent-managed' option. Focus Items using 'Full tracking' or the legacy snippet always activate tracking immediately, regardless of this setting.
 
-It's safe to leave a manual ``enableMauticFocusTracking{id}()`` wiring in place when this setting is on - you don't need both, but keeping the callback wiring does no harm.
+Turning this setting on or off only changes the snippets Mautic shows for copying in the configuration UI. It doesn't alter Focus scripts already deployed on live sites. To apply the change to an existing embed, copy the updated snippet again and redeploy it.
 
-When you leave the option off, you manage Focus tracking consent independently through the ``enableMauticFocusTracking{id}()`` callback described in the 'Consent-managed' section.
+It's safe to leave a manual ``window.MauticFocus.enableTracking(<id>)`` call in place when this setting is on - you don't need both, but keeping it does no harm.
+
+When it's off, you manage Focus tracking consent independently by calling ``window.MauticFocus.enableTracking(<id>)`` as described in the 'Consent-managed' section.
 
 .. vale off
 
@@ -254,7 +263,7 @@ Embedding in a Landing Page or Email
 
 .. vale on
 
-You can also embed a Focus Item in a Landing Page or Email using a page-builder token. Three variants are available:
+You can also embed a Focus Item in a Landing Page or Email using a page-builder token. Unlike the website embed, a bare ``{focus=ID}`` token activates tracking; only the ``{focus=ID|display}`` variant is display-only. Three variants are available:
 
 * ``{focus=ID}`` and ``{focus=ID|tracking}`` - load the display script and activate tracking together, matching the legacy behavior.
 * ``{focus=ID|display}`` - load the display script only, with no tracking.

--- a/docs/channels/focus_items.rst
+++ b/docs/channels/focus_items.rst
@@ -200,16 +200,68 @@ Once you have created your Focus Item, you're ready to activate it to your websi
 Deploying to a website
 ======================
 
-When you save the Focus Item, Mautic shows the code snippet required to display it on your website in a green box on the Focus Item overview.
+When you save the Focus Item, Mautic shows the code required to display it on your website in a green box on the Focus Item overview. The install panel now presents these options in a tabbed panel with two embedding approaches - 'Consent-managed' and 'Full tracking'. The legacy single script snippet still works unchanged, so any Focus Item you've already embedded keeps working without changes.
 
   .. image:: images/focus_items/focus_item_embed.png
     :width: 400
     :alt: Screenshot showing the Focus Item code to embed within a website.
 
-.. note:: 
-    You may need assistance from your web development team to implement the Focus Item tracking code on your website.  
+.. note::
+    You may need assistance from your web development team to implement the Focus Item tracking code on your website.
 
     You must also ensure that you have specified your website's domain where you expect to use the Focus Item in the CORS settings for your Mautic instance, otherwise it won't appear. To verify this, go to Settings > Configuration > System Settings > CORS Settings and set Restricted Domains to Yes. Ensure that you specify your domain in the relevant field. Alternatively (but not recommended, as this would allow other websites to display your Focus Items), set Restrict Domains to No and don't specify your domains.
+
+Consent-managed
+~~~~~~~~~~~~~~~
+
+The 'Consent-managed' option gives you two pieces that you use together:
+
+* A *display* script that loads and shows the Focus Item without any Mautic tracking.
+* A *tracking activation* snippet that exposes a JavaScript callback named ``enableMauticFocusTracking{id}()``, where ``{id}`` is the Focus Item's ID. Your site's developer wires this callback into your consent-management platform (CMP) so that Focus tracking starts only after the visitor grants consent. Your site's developer makes this connection - it's a hand-off to your web development team.
+
+Use the 'Consent-managed' option when your site must wait for the visitor's consent decision before Focus tracking can start.
+
+Both the display script and the tracking activation snippet go on the page; only the *call* to ``enableMauticFocusTracking{id}()`` is gated by consent. If the visitor never consents, the callback is simply never called: the Focus Item still displays, and Mautic just doesn't track it.
+
+Mautic doesn't collect, store, or prove consent - it only separates displaying the Focus Item from activating tracking. Your site's own consent mechanism controls when tracking starts.
+
+If your Mautic administrator has turned on 'Use Mautic consent for Focus tracking' (see 'Bridging Mautic website-tracking consent' below), you don't need to wire ``enableMauticFocusTracking{id}()`` separately - the two approaches are alternatives.
+
+Full tracking
+~~~~~~~~~~~~~
+
+The 'Full tracking' option is a single snippet that loads the display script and then immediately activates tracking. This is equivalent to the legacy embed behavior. Use it only when consent already exists at page load, or when you handle consent through another mechanism outside of Mautic.
+
+Bridging Mautic website-tracking consent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Mautic's global Configuration includes a 'Use Mautic consent for Focus tracking' option under Tracking Settings, turned off by default. See :doc:`/configuration/settings` for where to find it.
+
+When you turn this option on, the copied website-tracking snippet bridges the visitor's Mautic website-tracking consent to Focus tracking. Focus tracking then activates automatically once the visitor grants Mautic website-tracking consent, so you don't need to wire ``enableMauticFocusTracking{id}()`` into a separate CMP. This is the same consent that Mautic's website tracking script uses.
+
+For the bridge to gate Focus tracking on consent, your website's own Mautic tracking must itself be set up as consent-managed; otherwise Focus tracking activates as soon as Mautic tracking loads. See :doc:`/configuration/tracking_script` for how to set up consent-managed website tracking.
+
+This setting only affects Focus Items embedded with the 'Consent-managed' option. Focus Items using 'Full tracking' or the legacy snippet always activate tracking immediately, regardless of this setting.
+
+It's safe to leave a manual ``enableMauticFocusTracking{id}()`` wiring in place when this setting is on - you don't need both, but keeping the callback wiring does no harm.
+
+When you leave the option off, you manage Focus tracking consent independently through the ``enableMauticFocusTracking{id}()`` callback described in the 'Consent-managed' section.
+
+.. vale off
+
+Embedding in a Landing Page or Email
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. vale on
+
+You can also embed a Focus Item in a Landing Page or Email using a page-builder token. Three variants are available:
+
+* ``{focus=ID}`` and ``{focus=ID|tracking}`` - load the display script and activate tracking together, matching the legacy behavior.
+* ``{focus=ID|display}`` - load the display script only, with no tracking.
+
+The ``{focus=ID|display}`` variant renders the Focus Item without tracking; the consent-managed activation flow described above applies to the website script embed, not to tokens. Use ``{focus=ID}`` or ``{focus=ID|tracking}`` when you want tracking with the token embed.
+
+See :doc:`/configuration/variables` for the full list of tokens.
 
 .. vale off
 

--- a/docs/components/dynamic_web_content.rst
+++ b/docs/components/dynamic_web_content.rst
@@ -73,6 +73,8 @@ The following values are available:
    *  Form: {form=ID#}
    *  Focus item: {focus=ID#}
 
+   The Focus item token also supports the ``{focus=ID#|display}`` and ``{focus=ID#|tracking}`` variants. See :doc:`/channels/focus_items` for details.
+
 .. vale on
 
 **Category** - Assign a Category to help you organize your Dynamic Web Content items. See :doc:`/categories/categories-overview` for more information.

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -797,7 +797,9 @@ Mautic tracking settings
 * **Do Not Track 404 error for anonymous Contacts** - Select **Yes** to not track page hits on any 404 error page tracked by the tracking code. This option helps prevent filling your logs with hits from bots.
 
 * **Append Segment IDs to Tracking URLs** - Select **Yes** to enable Mautic to append Segment IDs to the tracking URLs in Emails sent from Mautic. This allows Mautic to track which Segment a Contact belongs to when they click a link in an Email.
-  
+
+* **Use Mautic consent for Focus tracking** - Off by default. When set to **Yes**, the visitor's Mautic website-tracking consent also activates Focus Item tracking automatically, once granted. This relies on your website tracking being set up as consent-managed. When off, you manage Focus tracking consent independently. See :doc:`/channels/focus_items` for details.
+
 .. note:: 
 
   * The tracking code automatically detects the Preferred Timezone and Preferred Locale fields.

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -798,7 +798,7 @@ Mautic tracking settings
 
 * **Append Segment IDs to Tracking URLs** - Select **Yes** to enable Mautic to append Segment IDs to the tracking URLs in Emails sent from Mautic. This allows Mautic to track which Segment a Contact belongs to when they click a link in an Email.
 
-* **Use Mautic consent for Focus tracking** - Off by default. When set to **Yes**, the visitor's Mautic website-tracking consent also activates Focus Item tracking automatically, once granted. This relies on your website tracking being set up as consent-managed. When off, you manage Focus tracking consent independently. See :doc:`/channels/focus_items` for details.
+* **Use Mautic consent for Focus tracking** - Off by default. Find it under the 'Script modifiers' heading on the Tracking Settings tab. When set to **Yes**, Focus tracking activates automatically once the visitor grants Mautic website-tracking consent. This works only when your website manages Mautic tracking through consent; if it doesn't, Focus tracking activates as soon as Mautic tracking loads, with no consent gating. This setting affects only Focus Items embedded with the 'Consent-managed' option. 'Full tracking' and legacy embeds always activate tracking immediately. When off, you manage Focus tracking consent independently. See :doc:`/channels/focus_items` and :doc:`/configuration/tracking_script` for details.
 
 .. note:: 
 

--- a/docs/configuration/tracking_script.rst
+++ b/docs/configuration/tracking_script.rst
@@ -62,7 +62,7 @@ The **Consent-managed** tab gives you two snippets that you use together, and th
 
    .. vale off
 
-   Separately embedded Focus Items track views and interactions independently of Mautic website tracking. Loading only the essential script doesn't turn off Focus Item tracking, so you still need to manage consent separately for those Focus Items. See :doc:`/channels/focus_items` for how to embed a Focus Item on your website.
+   By default, separately embedded Focus Items track views and interactions independently of Mautic website tracking, so you manage their consent separately. Loading only the essential script doesn't turn off Focus Item tracking. If you turn on the 'Use Mautic consent for Focus tracking' setting, Mautic instead bridges website-tracking consent to Focus tracking. See :doc:`/channels/focus_items` for how to embed a Focus Item and manage its consent.
 
    .. vale on
 

--- a/docs/configuration/variables.rst
+++ b/docs/configuration/variables.rst
@@ -193,7 +193,7 @@ See :doc:`Components</components/assets>` and :doc:`Manage Pages</components/lan
    * - Asset link for Asset id#
      - ``{assetlink=25}``
    * - Focus Item id#
-     - ``{focus=4}``
+     - ``{focus=4}`` loads the display script and activates tracking together (same as ``{focus=4|tracking}``); use ``{focus=4|display}`` for display only
    * - Form id#
      - ``{form=83}``
    * - Landing Page link for page id#
@@ -385,9 +385,9 @@ Alphabetical list
    * - Fax
      - ``{contactfield=fax}``
    * - Focus Item id#
-     - ``{focus=4}``
+     - ``{focus=4}`` loads the display script and activates tracking together (same as ``{focus=4|tracking}``); use ``{focus=4|display}`` for display only
    * - Form id#
-     - ``{form=83}`` 
+     - ``{form=83}``
    * - Fax (Company)
      - ``{contactfield=companyfax}`` 
    * - First Name

--- a/docs/links/mautic_focus_item_scripts_docs.py
+++ b/docs/links/mautic_focus_item_scripts_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Focus Item scripts docs"
+link_text = "Focus Item scripts"
+link_url = "https://devdocs.mautic.org/en/7.2/mauticjs_api/focus_scripts.html"
+
+link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/26a3ac3d-4728-4887-90cf-d004a0e8d193)

Documents the consent-aware Focus Item embedding introduced by mautic/mautic PR #16926, which splits the Focus Item embed JavaScript so a site can display a Focus Item before tracking consent and activate tracking only after consent (GDPR).

**Updated to match the now-ready source PR (head `ebe9fdfb`).** This suggestion was first drafted against an earlier draft of the source PR; it has been reconciled to the current implementation.

In the "Deploying to a website" section of `docs/channels/focus_items.rst`, this describes the renamed 'Focus implementation' panel, which offers two options for external websites — 'Consent-managed' (a display script plus a tracking activation snippet that calls the public `window.MauticFocus.enableTracking(<id>)` API) and 'Full tracking' (a single snippet that activates tracking immediately) — plus copyable Landing Page tokens. It states plainly that Mautic doesn't record or verify consent; it only separates displaying the Focus Item from activating tracking.

It also documents the global 'Use Mautic consent for Focus tracking' setting (off by default, under the 'Script modifiers' heading on the Tracking Settings tab) that bridges Mautic website-tracking consent to Focus tracking — including the scope limit (Consent-managed embeds only) and a warning that, without consent-managed website tracking, Focus tracking activates with no consent gating. The `{focus=ID|display}` / `{focus=ID|tracking}` page-builder token variants are documented, and supporting cross-references were added/updated in `configuration/settings.rst`, `configuration/variables.rst`, `configuration/tracking_script.rst`, and `components/dynamic_web_content.rst`. A new `docs/links/mautic_focus_item_scripts_docs.py` xref link points to the developer documentation.

**Reconciliation note:** the earlier draft described a generated per-item `enableMauticFocusTracking{id}()` callback; that named callback does not exist in the ready source. The documented public entry point is `window.MauticFocus.enableTracking(<id>)`.

Targets the 7.2 docs branch (source base 7.x).