### PR TITLE
fix: repair malformed JSON in .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -284,6 +284,9 @@
       "profile": "https://github.com/vukovicpredrag",
       "contributions": [
         "review"
+      ]
+    },
+    {
       "login": "dcjarvis",
       "name": "David Jarvis aka DJ",
       "avatar_url": "https://avatars.githubusercontent.com/u/8997755?v=4",


### PR DESCRIPTION
## What does this PR do?

Fixes the malformed JSON in `.all-contributorsrc` that is currently causing the all-contributors bot to fail with:

> This project's configuration file has malformed JSON: .all-contributorsrc. Error:: Unexpected string in JSON at position 7727

## Why is this needed?

The merge commit e6aa9f1c combined the all-contributors additions for `vukovicpredrag` and `dcjarvis`, but dropped the three lines that close the first contributor object and open the second one:

```json
      "profile": "https://github.com/vukovicpredrag",
      "contributions": [
        "review"
      "login": "dcjarvis",
```

This leaves the file invalid, so the bot can no longer parse it and new contributors can't be added.

## How does it work?

Restores the missing `]`, `},` and `{`. Both contributor entries are preserved with their original data, and the file now parses as valid JSON with 32 contributors.

Both contributors are already listed correctly in `README.md`, so no README changes are needed.

## How to test

```bash
python3 -m json.tool .all-contributorsrc > /dev/null && echo "valid"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)