### PR TITLE
Correct Embedded Form note: snippets use the configured Site URL

### DIFF
--- a/docs/components/forms.rst
+++ b/docs/components/forms.rst
@@ -534,8 +534,13 @@ Embedded
 
 The Embedded option for embedding Mautic Forms uses JavaScript and ensures that the Forms on your website are always up to date with what you have set in Mautic. If you make changes to the Form in Mautic, you don't have to worry about re-copying the Form code everywhere you use the Form. Features including auto-fill and progressive profiling **only** works with the Embedded option.
 
+.. vale off
+
 .. note::
-  Before copying the code to embed your Mautic Forms, ensure that you are on the correct domain name - not a staging area or internal reference for example - as the Form embed code references the URL.
+
+   The Embedded snippets — both the JavaScript ``<script>`` snippet and the IFrame snippet — use your configured **Site URL**. This includes its scheme, host, and base path, not just the domain you're currently viewing Mautic on. To control where the embedded code points, set the :ref:`Site URL <site-url>` under **Configuration** > **System Settings** > **General Settings**. If **Site URL** isn't set, the snippets fall back to the current request host.
+
+.. vale on
 
 Via JavaScript
 ~~~~~~~~~~~~~~

--- a/docs/components/forms.rst
+++ b/docs/components/forms.rst
@@ -542,7 +542,7 @@ The Embedded option for embedding Mautic Forms uses JavaScript and ensures that 
 
 .. note::
 
-   The Embedded snippets — both the JavaScript ``<script>`` snippet and the IFrame snippet — use your configured **Site URL**. This includes its scheme, host, and base path, not just the domain you're currently viewing Mautic on. To control where the embedded code points, set the :ref:`Site URL <site-url>` under **Configuration** > **System Settings** > **General Settings**. If **Site URL** isn't set, the snippets fall back to the current request host.
+   The Embedded snippets - both the JavaScript ``<script>`` snippet and the IFrame snippet - use your configured **Site URL**. This includes its scheme, host, and base path, not just the domain you're currently viewing Mautic on. To control where the embedded code points, set the :ref:`Site URL <site-url>` under **Configuration** > **System Settings** > **General Settings**. If you haven't set the **Site URL**, the snippets fall back to the current request host.
 
 .. vale on
 

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -14,6 +14,8 @@ General settings
   :width: 600
   :alt: Screenshot showing General Settings Configuration in Mautic
 
+.. _site-url:
+
 * **Site URL** - This is where Mautic is physically installed. Set the URL for this site here. Cron jobs needs this to correctly determine absolute URLs when generating links for Emails, etc. It 's also called Mautic's 'base URL'.
 
 * **Mautic's root URL** - When a User signs in to their Mautic instance, they go to ``mautic.example.com``. However, that Landing Page is also accessible to the public. If a Contact visits that address, they see the Mautic login page for that instance.


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/8a41c6dd-8c71-4149-8d3b-edcadf3bd745)

The Embedded Form JavaScript and IFrame snippets now use your configured **Site URL** — its scheme, host, and base path — rather than the domain of the admin host you're currently viewing Mautic on. This corrects the note under the **Embedded** heading in the Forms docs, which previously told users to be on the correct domain because the embed code referenced the current URL. The note now explains that the Embedded snippets use the configured Site URL, points readers to set it under **Configuration** > **System Settings** > **General Settings**, and notes the fallback to the current request host when Site URL is unset. A cross-reference to the Site URL configuration setting is added. The Self-hosted (manual copy) note is unchanged, since those snippets still reference the current host.

**Trigger Events**
- [mautic/mautic PR #17193: Use configured site URL for form embeds without changing admin links](https://github.com/mautic/mautic/pull/17193)