### PR TITLE
docs: cherry-pick #927 Point Actions nav path and label update (7.1)

### DIFF
--- a/docs/points/points.rst
+++ b/docs/points/points.rst
@@ -15,7 +15,7 @@ Point Actions are those times when a Contact receives a change in their Point to
 
 To add a new action:
 
-1. Click **Points > Point Actions > + New**  - located in the top right corner.
+1. Click **Points > Manage Actions > New**  - located in the top right corner.
 
 .. image:: images/new_points_action.png
     :alt: Screenshot of New Points action
@@ -28,7 +28,7 @@ To add a new action:
 
    * **Change Points (+/-)** - The value change to set for the action. The ``+`` isn't necessary when adding Points. When subtracting Points, add the ``-`` symbol.
 
-   * **Actions taken by User** - This is the behavior or action the Contact must complete to trigger the action.
+   * **Actions taken by Contact** - This is the behavior or action the Contact must complete to trigger the action.
 
 3. On the right side is more information:
 

--- a/docs/points/points.rst
+++ b/docs/points/points.rst
@@ -15,7 +15,7 @@ Point Actions are those times when a Contact receives a change in their Point to
 
 To add a new action:
 
-1. Click **Points > Manage Actions > New**  - located in the top right corner.
+1. Click **Points > Manage Actions > New** - located in the top right corner.
 
 .. image:: images/new_points_action.png
     :alt: Screenshot of New Points action


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/6a914516-11a9-4621-8cb3-2b4424c1605a)

Cherry-picks the two text corrections from merged PR #927 (originally applied to the 7.0 branch) onto 7.1. In `docs/points/points.rst`, the Point Actions creation step now reads **Points > Manage Actions > New** instead of **Points > Point Actions > + New**, matching the current UI navigation, and the field label reference changes from **Actions taken by User** to **Actions taken by Contact**. The result on 7.1 is identical to the merged 7.0 content.

**Trigger Events**
- [GitHub PR #927 comment from @adiati98 requesting the cherry-pick](https://github.com/mautic/user-documentation/pull/927#issuecomment-5496646268)
