### PR TITLE
Document explicit Email click tracking exception under GPC/DNT signals

### DIFF
--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -834,6 +834,16 @@ To keep your analytics focused on real people, Mautic automatically excludes cer
 
 This filtering is always on, and you can't turn it off. Because Mautic doesn't track these requests, it doesn't create anonymous Contacts for them, so your analytics reflect genuine human engagement and respect visitor privacy preferences.
 
+.. vale off
+
+.. note::
+
+   This always-on filtering covers passive and background tracking, not a Contact's own explicit actions. When a Contact clicks a tracked link in an Email, Mautic records that click even if the request carries a ``Sec-GPC: 1`` or ``DNT: 1`` header, because clicking a link is an explicit, intentional action. As a result, Mautic records the page hit with its Email association, marks the Email as read, and evaluates the **Clicks Email** Campaign decision as met. The visitor still reaches the link's destination exactly as before.
+
+   This exception applies only to an explicit click on a tracked link in an Email. Passive Landing Page visits, Email opens, Asset downloads, and background Contact tracking under a Global Privacy Control or Do Not Track signal are still not recorded. The Bots and crawlers, HEAD requests, and Speculative loading requests conditions still block tracking, even for a click on a link in an Email.
+
+.. vale on
+
 Facebook pixel
 ==============
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/8a6da381-08e8-47a9-8f49-849ea4705b93)

Mautic 7.2 (mautic/mautic PR #17257, fixing issue #17187) changes what the "Automatic tracking filtering" section describes: an explicit click on a tracked link in an Email is now recorded even when the browser sends a `Sec-GPC: 1` or `DNT: 1` signal, because clicking is an explicit user action rather than passive tracking. The click records a page hit with its Email association, marks the Email as read, and lets the Clicks Email Campaign decision evaluate — restoring click-based Campaign flows (such as double opt-in) for privacy-signal users. Passive Landing Page visits, Email opens, Asset downloads, and background Contact tracking under those signals remain untracked, and bot, HEAD, and speculative-loading filtering still block tracking even for an Email link click.

This adds a scoped note to that section in docs/configuration/settings.rst so the "always on, you can't turn it off" framing no longer reads as blocking every request under a privacy signal. No new setting or configuration is involved — the behavior is automatic.

**Trigger Events**
- [GitHub PR mautic/mautic#17257: allow tracked email click redirects through GPC/DNT privacy signals](https://github.com/mautic/mautic/pull/17257)