### PR TITLE
Fix dead X developer link that breaks linkcheck

### DIFF
--- a/docs/links/X-developer.py
+++ b/docs/links/X-developer.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "X-developer" 
 link_text = "X-developer" 
-link_url = "https://developer.twitter.com/en/portal/petition/essential/basic-info/" 
+link_url = "https://docs.x.com/fundamentals/developer-apps"
 
 link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/5b76e773-5007-47ee-aabc-cc19c32b18de)

The `X-developer` xref (used in the social login setup requirements list in `docs/plugins/social_login.rst`) pointed at `https://developer.twitter.com/en/portal/petition/essential/basic-info/`, which now redirects to an X login wall and returns a `403` to the link checker. This fails `make checklinks` (Sphinx linkcheck) and turns the build check red on the 7.1 branch.

This points the xref at X's stable, login-free canonical developer-apps documentation (`https://docs.x.com/fundamentals/developer-apps`), which still explains how to create a developer app and obtain API keys — the same guidance the original link served. Only the link definition in `docs/links/X-developer.py` changes; no prose is affected.
