### PR TITLE
Fix dead X developer link that breaks linkcheck (7.0)

### DIFF
--- a/docs/links/X-developer.py
+++ b/docs/links/X-developer.py
@@ -2,6 +2,6 @@ from . import link
 
 link_name = "X-developer" 
 link_text = "X-developer" 
-link_url = "https://developer.twitter.com/en/portal/petition/essential/basic-info/" 
+link_url = "https://docs.x.com/fundamentals/developer-apps"
 
 link.xref_links.update({link_name: (link_text, link_url)})


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/bd38bb6f-6d71-4b44-8d6f-cf021696f25a)

Cherry-picks the X-developer link fix from #947 (merged into `7.1`) onto the `7.0` branch, which still carries the dead link.

The `X-developer` xref pointed at `https://developer.twitter.com/en/portal/petition/essential/basic-info/`, which now redirects to an X login wall and returns an `HTTP 403` to the link checker. This fails Sphinx linkcheck (`make checklinks`) and turns the build check red. It now points at X's stable, login-free canonical developer-apps documentation (`https://docs.x.com/fundamentals/developer-apps`), which still explains how to create a developer app and obtain API keys — the same guidance the original link served.

Only the link definition in `docs/links/X-developer.py` changes; no prose is affected.

**Trigger Events**
- [Maintainer request on mautic/user-documentation#947](https://github.com/mautic/user-documentation/pull/947#issuecomment-5553600681)