### PR TITLE
Update Points navigation and field information for the Mautic 6.0 UI

### DIFF
--- a/docs/points/points.rst
+++ b/docs/points/points.rst
@@ -15,12 +15,12 @@ Point Actions are those times when a Contact receives a change in their Point to
 
 To add a new action:
 
-1. Click **Points > Point Actions > + New**  - located in the top right corner.
+1. On the left side, navigate to **Points > Manage Actions** and click the **New** button located in the top right corner to open the **New Point Action** window.
 
 .. image:: images/points-action.png
     :alt: Screenshot of Points action
 
-2. In the main panel, there are four boxes for key information. Enter the appropriate information.
+2. In the main panel, fill in the following fields:
 
    * **Name** - The name of your action. This is how the action displays in your list of actions, so choose an identifiable name.
 
@@ -28,7 +28,9 @@ To add a new action:
 
    * **Change Points (+/-)** - The value change to set for the action. The ``+`` isn't necessary when adding Points. When subtracting Points, add the ``-`` symbol.
 
-   * **Actions taken by User** - This is the behavior or action the Contact must complete to trigger the action.
+   * **Action taken by Contact** - The specific Contact activity required to trigger the Point Action.
+
+   * **Point Group** - Identify the target group for the action. If you leave this empty, the action applies to the Contact's overall Points total instead of a specific group.
 
 3. On the right side is more information:
 
@@ -49,10 +51,20 @@ Point Triggers
 
 Once a Contact has accumulated a Point total, you may want to trigger an action with the Contact. You may create multiple triggers for different Point values.
 
+To add a new trigger:
+
+1. On the left side, navigate to **Points > Manage Triggers** and click the **New** button located in the top right corner to create a new Point Trigger.
+
 .. image:: images/points-trigger.png
     :alt: Screenshot of Points trigger
 
-Creating Point Triggers is like creating Point Actions. The **Name**, **Description**, **Category**, and **Active** options are all the same. The trigger fires based on the minimum number of Points. Set a number and decide if you want to **Trigger for existing applicable Contacts upon saving - if activated**. 
+2. Complete the main panel information. Use the **Name**, **Description**, **Point Group**, and **Category** fields as you do for Point Actions. The **Active and Activate/Deactivate at date/time** settings also work the same way. Then, fill in these extra fields:
+
+   * **Minimum number of Points** - The minimum number of Points a Contact must reach for this Point Trigger to fire.
+
+   * **Contact color** - This sets a highlight color for Contacts who earn at least the minimum number of Points.
+
+   * **Trigger for existing applicable Contacts upon saving** - Select **Yes** to apply this trigger to Contacts who already have the minimum number of Points.
 
 Once you have decided and entered those options, go to the **Events** tab. Here, you can trigger one or more events once a Contact has reached your predetermined Point total. These Point Triggers and associated events are also fully customizable.
 

--- a/docs/points/points.rst
+++ b/docs/points/points.rst
@@ -61,10 +61,8 @@ To add a new trigger:
 2. Complete the main panel information. Use the **Name**, **Description**, **Point Group**, and **Category** fields as you do for Point Actions. The **Active and Activate/Deactivate at date/time** settings also work the same way. Then, fill in these extra fields:
 
    * **Minimum number of Points** - The minimum number of Points a Contact must reach for this Point Trigger to fire.
-
    * **Contact color** - This sets a highlight color for Contacts who earn at least the minimum number of Points.
-
-   * **Trigger for existing applicable Contacts upon saving** - Select **Yes** to apply this trigger to Contacts who already have the minimum number of Points.
+   * **Trigger for existing applicable Contacts upon saving** - Select 'Yes' to apply this trigger to Contacts who already have the minimum number of Points.
 
 Once you have decided and entered those options, go to the **Events** tab. Here, you can trigger one or more events once a Contact has reached your predetermined Point total. These Point Triggers and associated events are also fully customizable.
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/2c670f52-1145-4262-9223-cdf1de4bafc2)

Aligns `docs/points/points.rst` with the current Mautic 6.0 UI so readers see the same menu items and field labels the product shows. Updates the Point Action and Point Trigger creation steps to use the **Points > Manage Actions** and **Points > Manage Triggers** navigation, renames the **Action taken by Contact** field (previously "Actions taken by User"), documents the new **Point Group** field, and adds explicit steps and field descriptions (**Minimum number of Points**, **Contact color**, **Trigger for existing applicable Contacts upon saving**) to the Point Triggers section. This applies to branch 6.0 the same UI-alignment change that merged PR #651 made for branch 5.2 (issue #498); this is the branch-6.0 sibling issue #499. No screenshots changed.

Closes #499

**Trigger Events**
- [GitHub issue comment on mautic/user-documentation#499: request to pick up the 6.0 Points docs update, using PR #651 as reference](https://github.com/mautic/user-documentation/issues/499#issuecomment-5558085120)
