### PR TITLE
Port Points navigation and field updates from PR #954 to branch 7.2

### DIFF
--- a/docs/points/points.rst
+++ b/docs/points/points.rst
@@ -51,9 +51,7 @@ Point Triggers
 
 Once a Contact has accumulated a Point total, you may want to trigger an action with the Contact. You may create multiple triggers for different Point values.
 
-To add a new trigger:
-
-1. Click **Points > Manage Triggers > New** - located in the top right corner.
+To add a new trigger, click **Points > Manage Triggers > New** - located in the top right corner.
 
 .. image:: images/new_points_trigger.png
     :alt: Screenshot of New Points trigger
@@ -61,10 +59,8 @@ To add a new trigger:
 Creating Point Triggers is like creating Point Actions. The **Name**, **Description**, **Category**, and **Active** options are all the same. Point Triggers also include the following options:
 
 * **Minimum number of Points** - The minimum number of Points a Contact must reach for this Point Trigger to fire.
-
 * **Contact color** - This sets a highlight color for Contacts who earn at least the minimum number of Points.
-
-* **Trigger for existing applicable Contacts upon saving** - Select **Yes** to apply this trigger to Contacts who already have the minimum number of Points.
+* **Trigger for existing applicable Contacts upon saving** - Select 'Yes' to apply this trigger to Contacts who already have the minimum number of Points.
 
 Once you have decided and entered those options, go to the **Events** tab. Here, you can trigger one or more events once a Contact has reached your predetermined Point total. These Point Triggers and associated events are also fully customizable.
 

--- a/docs/points/points.rst
+++ b/docs/points/points.rst
@@ -15,7 +15,7 @@ Point Actions are those times when a Contact receives a change in their Point to
 
 To add a new action:
 
-1. Click **Points > Manage Actions > New** - located in the top right corner.
+1. On the left side, navigate to **Points > Manage Actions** and click the **New** button located in the top right corner to open the **New Point Action** window.
 
 .. image:: images/new_points_action.png
     :alt: Screenshot of New Points action
@@ -51,7 +51,7 @@ Point Triggers
 
 Once a Contact has accumulated a Point total, you may want to trigger an action with the Contact. You may create multiple triggers for different Point values.
 
-To add a new trigger, click **Points > Manage Triggers > New** - located in the top right corner.
+To add a new trigger, on the left side, navigate to **Points > Manage Triggers** and click the **New** button located in the top right corner to create a new Point Trigger.
 
 .. image:: images/new_points_trigger.png
     :alt: Screenshot of New Points trigger

--- a/docs/points/points.rst
+++ b/docs/points/points.rst
@@ -20,7 +20,7 @@ To add a new action:
 .. image:: images/new_points_action.png
     :alt: Screenshot of New Points action
 
-2. In the main panel, there are four boxes for key information. Enter the appropriate information.
+2. In the main panel, there are five boxes for key information. Enter the appropriate information.
 
    * **Name** - The name of your action. This is how the action displays in your list of actions, so choose an identifiable name.
 
@@ -28,7 +28,9 @@ To add a new action:
 
    * **Change Points (+/-)** - The value change to set for the action. The ``+`` isn't necessary when adding Points. When subtracting Points, add the ``-`` symbol.
 
-   * **Actions taken by Contact** - This is the behavior or action the Contact must complete to trigger the action.
+   * **Action taken by Contact** - This is the behavior or action the Contact must complete to trigger the action.
+
+   * **Point Group** - Identify the target group for the action. If you leave this empty, the action applies to the Contact's overall Point total instead of a specific group.
 
 3. On the right side is more information:
 
@@ -49,10 +51,20 @@ Point Triggers
 
 Once a Contact has accumulated a Point total, you may want to trigger an action with the Contact. You may create multiple triggers for different Point values.
 
+To add a new trigger:
+
+1. Click **Points > Manage Triggers > New** - located in the top right corner.
+
 .. image:: images/new_points_trigger.png
     :alt: Screenshot of New Points trigger
 
-Creating Point Triggers is like creating Point Actions. The **Name**, **Description**, **Category**, and **Active** options are all the same. The trigger fires based on the minimum number of Points. Set a number and decide if you want to **Trigger for existing applicable Contacts upon saving - if activated**. 
+Creating Point Triggers is like creating Point Actions. The **Name**, **Description**, **Category**, and **Active** options are all the same. Point Triggers also include the following options:
+
+* **Minimum number of Points** - The minimum number of Points a Contact must reach for this Point Trigger to fire.
+
+* **Contact color** - This sets a highlight color for Contacts who earn at least the minimum number of Points.
+
+* **Trigger for existing applicable Contacts upon saving** - Select **Yes** to apply this trigger to Contacts who already have the minimum number of Points.
 
 Once you have decided and entered those options, go to the **Events** tab. Here, you can trigger one or more events once a Contact has reached your predetermined Point total. These Point Triggers and associated events are also fully customizable.
 

--- a/docs/points/points.rst
+++ b/docs/points/points.rst
@@ -20,7 +20,7 @@ To add a new action:
 .. image:: images/new_points_action.png
     :alt: Screenshot of New Points action
 
-2. In the main panel, there are five boxes for key information. Enter the appropriate information.
+2. In the main panel, fill in the following fields:
 
    * **Name** - The name of your action. This is how the action displays in your list of actions, so choose an identifiable name.
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/7115c31d-08f5-4518-8401-e19f5a094315)

Cherry-picks the Mautic UI-alignment change from PR #954 (branch 6.0) onto branch 7.2, aligning `docs/points/points.rst` with the Mautic 7.x Points UI. Renames the Point Action field to **Action taken by Contact** (singular, matching the product label), documents the new **Point Group** field on Point Actions, adds the **Points > Manage Triggers** navigation step, and expands the Point Triggers section with the **Minimum number of Points**, **Contact color**, and **Trigger for existing applicable Contacts upon saving** field descriptions. The 7.2 page already carried part of this alignment (the **Manage Actions** navigation and updated screenshots); this fills the remaining gaps. All navigation and field labels were verified against the Mautic 7.x product source before porting. No screenshots changed.

**Trigger Events**
- [Comment on mautic/user-documentation#954 requesting cherry-picks to other branches](https://github.com/mautic/user-documentation/pull/954#issuecomment-5558194703)

---

**Review response (@adiati98 — navigation wording consistency)**

Adopted PR #954's clearer, active-voice navigation wording on this branch so the three ports (#956/#957/#958) stay consistent with their source PR #954, rather than changing #954. Two lines in `docs/points/points.rst` changed:

- Point Actions: *"On the left side, navigate to **Points > Manage Actions** and click the **New** button located in the top right corner to open the **New Point Action** window."*
- Point Triggers: *"To add a new trigger, on the left side, navigate to **Points > Manage Triggers** and click the **New** button located in the top right corner to create a new Point Trigger."* (kept as a single sentence, per your earlier request to collapse the one-item list)

Both applied verbatim from #954's wording. Vale passes on the changed file.