### PR TITLE
Fix Themes developer-docs link on Theme Structure page (backport of #667 to 7.1)

### DIFF
--- a/docs/links/mautic_getting_started_with_themes_docs.py
+++ b/docs/links/mautic_getting_started_with_themes_docs.py
@@ -1,0 +1,7 @@
+from . import link
+
+link_name = "Getting started with Themes"
+link_text = "Getting started with Themes"
+link_url = "https://devdocs.mautic.org/en/5.x/themes/getting_started.html"
+
+link.xref_links.update({link_name: (link_text, link_url)})

--- a/docs/themes/theme_structure.rst
+++ b/docs/themes/theme_structure.rst
@@ -5,4 +5,4 @@ Theme Structure
 
 .. vale on
 
-Visit the :xref:`Themes directory structure` section in the Developer Documentation for more details.
+Visit the :xref:`Getting started with Themes` section in the Developer Documentation for more details.


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/c7c72e7a-f86c-4085-8a79-d83c04cb0d6d)

Ports the merged fix from PR #667 (originally applied to 5.2) to the 7.1 branch. The Theme Structure page's closing cross-reference into the Developer Documentation pointed at the outdated "Themes directory structure" target; this updates it to the current "Getting started with Themes" destination and adds the corresponding `docs/links/mautic_getting_started_with_themes_docs.py` link definition so the `:xref:` resolves. The change is byte-identical to what was merged on 5.2.

**Trigger Events**
- [Maintainer comment on merged PR mautic/user-documentation#667 requesting cherry-pick to all branches](https://github.com/mautic/user-documentation/pull/667#issuecomment-5561014452)
