### PR TITLE
Document Schedule Send for Segment Text Messages

### DIFF
--- a/docs/channels/sms.rst
+++ b/docs/channels/sms.rst
@@ -31,7 +31,7 @@ Segment Text Messages
 
 .. vale on 
 
-A Segment Text Message can be manually sent to Contact lists - Segments - in Mautic. Once sent, you can't edit the Text Message, however you can send it to new Contacts as they join the associated Segment.
+A Segment Text Message can be manually sent to Contact lists - Segments - in Mautic. Once sent, you can't edit the Text Message. Whether the send continues to Contacts who join the associated Segment later is controlled by the **Continue sending** option when you schedule the send - see :ref:`schedule segment text message`.
 
 Note that these are marketing Text Messages by default, and each Contact can only receive the Text Message once - it's the same principle as a mailing list.
 
@@ -108,11 +108,44 @@ The following fields are available:
 
 **Contact Segment** - This allows you to define the Segment/s who should receive the Text Message.
 
+.. note::
+
+   For a Segment Text Message, you set the sending times with the **Schedule** button on the Text Message details page, not from the editor. See :ref:`schedule segment text message`.
+
 .. vale off
 
-**Publish at (date/time)** - This allows you to define the date and time at which this Text Message is available for sending to Contacts
+.. _schedule segment text message:
 
-**Unpublish at (date/time)** - This allows you to define the date and time at which this Text Message ceases to be available for sending to Contacts.
+Scheduling a Segment Text Message
+=================================
+
+.. vale on
+
+For a Segment Text Message, you control when the message goes out from its details page rather than from the message editor.
+
+The **Schedule** button appears on the details page of a Segment Text Message only - not on template or triggered Text Messages - and only for a User who has permission to publish the Text Message. If you don't see the button, ask an administrator for permission to publish Text Messages. It doesn't appear in embedded views. Once a schedule exists, the button label changes to **Update schedule**.
+
+To schedule the send:
+
+#. Open the details page of the Segment Text Message by selecting its name from the Channels > Text Messages list.
+#. Click **Schedule** to open the scheduling modal.
+#. Set the following controls:
+
+   * **Start sending date and time** - Required. The date and time when sending begins.
+   * **Continue sending** - Shown as a Yes/No question, this controls whether the send continues to include Contacts added to the Segment after sending starts.
+   * **Stop sending** - Appears only when **Continue sending** is Yes. The optional latest date and time to keep sending.
+
+When **Continue sending** is No - the default - Mautic performs a one-time send to the Contacts who are members of the Segment as of the start time. Contacts added to the Segment after the start time aren't included. After Mautic finishes sending to all pending Contacts, Mautic marks the Text Message as unpublished.
+
+When **Continue sending** is Yes, Mautic sends to the Contacts who are Segment members at the start time and continues to include Contacts added to the Segment afterward, until the optional **Stop sending** time.
+
+To change the scheduled times, reopen the modal with **Update schedule**. To clear the schedule, click **Cancel schedule** - cancelling clears the schedule so the Text Message won't send on that schedule. To dismiss the modal without saving changes, click **Close**.
+
+The publish-status badge on the details page reflects progress: it shows a sending state while Contacts are still pending, and a sent state once a one-time schedule has finished. A continuing send - where **Continue sending** is Yes - keeps showing the sending state until it reaches the optional **Stop sending** time, so a long-running sending state on a continuing send is expected rather than a fault.
+
+Cloning a scheduled Segment Text Message produces an unpublished copy with the schedule cleared.
+
+Scheduled sends run through the same ``Send Scheduled Broadcast`` Cron job that already sends Segment Text Messages. See :doc:`Cron jobs documentation </configuration/cron_jobs>` for more information. As with any Text Message send, you must first set up an SMS transport, as noted at the top of this page.
 
 .. vale off
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/32c1a8ca-3f1a-41b5-92b9-664d81124d48)

Mautic 7.x adds an explicit Schedule Send workflow for Segment Text Messages, mirroring the existing Segment Email scheduling. This adds a "Scheduling a Segment Text Message" section to the SMS channel page covering the Schedule button and its preconditions, the Start sending date and time / Continue sending / Stop sending modal controls, one-time versus continuing sends, Update schedule and Cancel schedule, the details-page sending status, and the cron prerequisite. It also reconciles the editor's Publish at / Unpublish at field description, which no longer sets sending times for Segment Text Messages, to point readers to the Schedule button.

Documents mautic/mautic#17310.

**Trigger Events**
- [Message in Slack channel #docs-notifications: maintainer confirmed docs branch 7.3 now exists](https://mautic.slack.com/archives/C0114H9GRH8/p1788961412506879)
