### PR TITLE
Document broadened Email link validation (relative, query-only, scheme-less, and space-containing URLs)

### DIFF
--- a/docs/channels/emails.rst
+++ b/docs/channels/emails.rst
@@ -833,6 +833,12 @@ A link is valid when its ``href``:
 * Uses one of these seven schemes: ``http``, ``https``, ``ftp``, ``ftps``, ``mailto``, ``tel``, or ``sms``
 * Is an anchor link that starts with ``#``
 * Is a Mautic token such as ``{unsubscribe_url}``
+* Is a path-relative link that starts with ``/``, such as ``/pricing``
+* Is a query-only link that starts with ``?``, such as ``?ref=email``
+* Omits the scheme but includes a domain and path, such as ``example.com/path``
+* Is an otherwise valid ``http``, ``https``, ``ftp``, or ``ftps`` URL that contains spaces or angle brackets, such as ``https://example.com/?tags=Tag Name -> Stage`` produced by the Email builder or by token replacement
+
+A save fails when a link uses ``javascript:`` or another pseudo-scheme, points to a bare filename with no host such as ``file.pdf``, or can't be parsed at all, like the ``://example.com`` in the earlier example.
 
 .. vale on
 


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/375f6f7b-f144-4c65-96b9-29d3385675c8)

Mautic's save-time Email link validation now accepts more `href` forms. The "Link validation" section of the Emails page previously listed only three valid forms (the seven schemes, `#` anchors, and Mautic tokens), so it no longer reflects what actually saves.

This update adds the newly accepted forms to that list — path-relative links (`/pricing`), query-only links (`?ref=email`), scheme-less host-and-path links (`example.com/path`), and otherwise-valid http/https/ftp/ftps URLs that contain spaces or angle brackets (such as those produced by the Email builder or by token replacement). It also adds a short note naming the forms that still fail validation (`javascript:` and other pseudo-schemes, bare filenames with no host, and unparseable strings), so a reader whose save is still blocked knows the cause is genuine.

Reflects the behavior introduced by mautic/mautic PR #17323.

**Trigger Events**
- [GitHub PR mautic/mautic#17323: ValidEmailLinksValidator: normalize-then-validate](https://github.com/mautic/mautic/pull/17323)
