### PR TITLE
docs: Document Visits specific URL Point Action options and cumulative time behavior

### DIFF
--- a/docs/points/points.rst
+++ b/docs/points/points.rst
@@ -40,6 +40,25 @@ To add a new action:
 
 4. Click **Save** or **Save & Close**.
 
+Visits specific URL
+===================
+
+The 'Visits specific URL' action awards Points when a Contact visits a URL that matches an address you specify. When you choose this action from 'Actions taken by User', Mautic displays these fields:
+
+* **Page URL** - The web address to track. Enter the full URL, including ``http://`` or ``https://``. Use ``*`` as a wildcard to match part of the address - for example, ``https://example.com/pricing*`` matches the pricing URL with any query string.
+
+* **Total time spent** - Awards Points once the Contact has spent at least this much time on the matching URL across all their visits.
+
+* **Page hits** - Awards Points once the Contact has visited the matching URL at least this many times.
+
+* **First visit only** - Awards Points only on the Contact's first visit to the matching URL.
+
+* **Returns within** and **Returns after** - Award Points when the Contact returns to the matching URL within, or after, the time period you set.
+
+'Total time spent' and 'Page hits' measure cumulative activity on the matching URL. Mautic evaluates them against the Contact's full visit history for that URL, so it awards the Points on the next tracked hit after the Contact crosses the threshold. The Contact doesn't need to revisit the specific URL. Because Mautic measures time spent from the tracking script, the Contact has to load another tracked URL before the most recent visit's time counts.
+
+The remaining options describe a single visit, so Mautic applies them only when the Contact's current hit matches the 'Page URL'.
+
 .. vale off
 
 Point Triggers


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/d0860b42-8485-4120-8932-c15463a1f3d8)

Adds a 'Visits specific URL' subsection to the Points page documenting the action's options (Page URL, Total time spent, Page hits, First visit only, Returns within/after). Clarifies that 'Total time spent' and 'Page hits' are cumulative across the Contact's visit history and award Points on the next tracked hit once the threshold is crossed — no revisit of the specific URL required — reflecting the fix in mautic/mautic PR #16606.

_This draft PR replaces #854, reopened as a fresh draft so the Read The Docs preview build triggers cleanly. The documentation changes are identical._

**Trigger Events**
- [mautic/mautic PR #16606: Fix visits URL Point action based on total time spent is not triggere…](https://github.com/mautic/mautic/pull/16606)

---

_Tip: Filter the [Dashboard](https://app.gopromptless.ai) by labels or assignees to focus on what matters to you 🔎_